### PR TITLE
Fix for EstimateVideoJumpTimes regression introduced in 0.4.0

### DIFF
--- a/neurotic/tests/metadata-for-tests.yml
+++ b/neurotic/tests/metadata-for-tests.yml
@@ -1,0 +1,15 @@
+remote_data_root: https://web.gin.g-node.org/jpgill86/neurotic-data/raw/master/tests
+
+events-and-epochs:
+    data_dir: events-and-epochs
+    remote_data_dir: events-and-epochs
+    data_file: events_and_epochs.axgx
+    video_file: test.avi
+
+    plots:
+        - channel: "Analog Input #5"
+          units: mV
+          ylim: [-5, 0]
+        - channel: Clock
+          units: V
+          ylim: [-0.1, 5.1]

--- a/neurotic/tests/test_cli.py
+++ b/neurotic/tests/test_cli.py
@@ -12,10 +12,13 @@ import pkg_resources
 import copy
 import yaml
 import unittest
+import logging
 
 from ephyviewer import mkQApp
 
-from ..scripts import parse_args, win_from_args
+import neurotic
+
+logger = logging.getLogger(__name__)
 
 class CLITestCase(unittest.TestCase):
 
@@ -61,9 +64,9 @@ class CLITestCase(unittest.TestCase):
     def test_cli_defaults(self):
         """Test CLI default values"""
         argv = ['neurotic']
-        args = parse_args(argv)
+        args = neurotic.parse_args(argv)
         app = mkQApp()
-        win = win_from_args(args)
+        win = neurotic.win_from_args(args)
         self.assertTrue(win.lazy, 'lazy loading disabled without --no-lazy')
         self.assertFalse(win.support_increased_line_width,
                          'thick traces enabled without --thick-traces')
@@ -77,17 +80,17 @@ class CLITestCase(unittest.TestCase):
     def test_no_lazy(self):
         """Test that --no-lazy disables lazy loading"""
         argv = ['neurotic', '--no-lazy']
-        args = parse_args(argv)
+        args = neurotic.parse_args(argv)
         app = mkQApp()
-        win = win_from_args(args)
+        win = neurotic.win_from_args(args)
         self.assertFalse(win.lazy, 'lazy loading enabled with --no-lazy')
 
     def test_thick_traces(self):
         """Test that --thick-traces enables support for thick traces"""
         argv = ['neurotic', '--thick-traces']
-        args = parse_args(argv)
+        args = neurotic.parse_args(argv)
         app = mkQApp()
-        win = win_from_args(args)
+        win = neurotic.win_from_args(args)
         self.assertTrue(win.support_increased_line_width,
                         'thick traces disabled with --thick-traces')
 
@@ -96,33 +99,33 @@ class CLITestCase(unittest.TestCase):
         app = mkQApp()
 
         argv = ['neurotic', '--theme', 'light']
-        args = parse_args(argv)
-        win = win_from_args(args)
+        args = neurotic.parse_args(argv)
+        win = neurotic.win_from_args(args)
         self.assertEquals(win.theme, 'light', 'unexpected theme')
 
         argv = ['neurotic', '--theme', 'dark']
-        args = parse_args(argv)
-        win = win_from_args(args)
+        args = neurotic.parse_args(argv)
+        win = neurotic.win_from_args(args)
         self.assertEquals(win.theme, 'dark', 'unexpected theme')
 
         argv = ['neurotic', '--theme', 'original']
-        args = parse_args(argv)
-        win = win_from_args(args)
+        args = neurotic.parse_args(argv)
+        win = neurotic.win_from_args(args)
         self.assertEquals(win.theme, 'original', 'unexpected theme')
 
     def test_file(self):
         """Test that metadata file can be set"""
         argv = ['neurotic', self.temp_file]
-        args = parse_args(argv)
-        win = win_from_args(args)
+        args = neurotic.parse_args(argv)
+        win = neurotic.win_from_args(args)
         self.assertEquals(win.metadata_selector.file, self.temp_file,
                           'file was not changed correctly')
 
     def test_dataset(self):
         """Test that dataset can be set"""
         argv = ['neurotic', self.temp_file, 'zzz_alphabetically_last']
-        args = parse_args(argv)
-        win = win_from_args(args)
+        args = neurotic.parse_args(argv)
+        win = neurotic.win_from_args(args)
         self.assertEquals(win.metadata_selector._selection,
                           'zzz_alphabetically_last',
                           'dataset was not changed correctly')

--- a/neurotic/tests/test_video_sync.py
+++ b/neurotic/tests/test_video_sync.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for video sync features
+"""
+
+import pkg_resources
+import tempfile
+import shutil
+import gc
+import unittest
+import logging
+
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+
+import neurotic
+
+logger = logging.getLogger(__name__)
+
+class VideoSyncUnitTest(unittest.TestCase):
+
+    def setUp(self):
+        self.file = pkg_resources.resource_filename(
+            'neurotic.tests', 'metadata-for-tests.yml')
+
+        # make a copy of the metadata file in a temp directory
+        self.temp_dir = tempfile.TemporaryDirectory(prefix='neurotic-')
+        self.temp_file = shutil.copy(self.file, self.temp_dir.name)
+
+    def tearDown(self):
+        # clean up references to proxy objects which keep files locked
+        gc.collect()
+
+        # remove the temp directory
+        self.temp_dir.cleanup()
+
+    def test_video_jumps(self):
+        """Test video jump estimation for AxoGraph file with pauses"""
+        dataset = 'events-and-epochs'
+        metadata = neurotic.MetadataSelector(file=self.temp_file,
+                                             initial_selection=dataset)
+        metadata.download('data_file')
+
+        blk = neurotic.LoadAndPrepareData(metadata=metadata, lazy=True)
+        video_jumps = neurotic.EstimateVideoJumpTimes(blk)
+        del blk
+
+        assert_array_almost_equal(
+            np.array(video_jumps),
+            np.array([[1.1998, 3], [4.6998, 3], [5.2998, 3]]),
+            decimal=12,
+            err_msg='EstimateVideoJumpTimes gave unexpected result')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/neurotic/utils.py
+++ b/neurotic/utils.py
@@ -158,10 +158,11 @@ def EstimateVideoJumpTimes(blk):
 
         # obtain exact stop times (AxoGraph time, not video time)
         event_stop_times = np.array([], dtype=np.float)
-        ev = blk.segments[0].events[0]
-        for time, label in zip(ev.times, ev.labels):
-            if label == 'Stop':
-                event_stop_times = np.append(event_stop_times, time.magnitude)
+        ev = next((ev for ev in blk.segments[0].events if ev.name == 'AxoGraph Tags'), None)
+        if ev is not None:
+            for time, label in zip(ev.times, ev.labels):
+                if label == 'Stop':
+                    event_stop_times = np.append(event_stop_times, time.magnitude)
 
         # pair stop times with pause durations
         video_jumps = []

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
     version = VERSION,
     description = 'Curate, visualize, and annotate your behavioral ephys data using Python',
     packages = find_packages(),
-    package_data = {'neurotic': ['example/metadata.yml']},
+    package_data = {'neurotic': ['example/metadata.yml'], 'neurotic.tests': ['metadata-for-tests.yml']},
     install_requires = install_requires,
     extras_require = extras_require,
     entry_points = {'console_scripts': ['neurotic=neurotic.scripts:main']},


### PR DESCRIPTION
`EstimateVideoJumpTimes` assumed the AxoGraph Tags were always first in the list, but #29 alphabetized the events list.