### PR TITLE
Add requirements files and license to source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+# metadata included in source distribution only
+include LICENSE
+include README.rst
+include requirements*.txt
+include environment.yml
+
+# package data included in source distribution and installation
+include neurotic/example/metadata.yml
+include neurotic/tests/metadata-for-tests.yml

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
     version = VERSION,
     description = 'Curate, visualize, and annotate your behavioral ephys data using Python',
     packages = find_packages(),
-    package_data = {'neurotic': ['example/metadata.yml'], 'neurotic.tests': ['metadata-for-tests.yml']},
+    include_package_data = True,
     install_requires = install_requires,
     extras_require = extras_require,
     entry_points = {'console_scripts': ['neurotic=neurotic.scripts:main']},


### PR DESCRIPTION
Adds requirements files and license to source distribution via new `MANIFEST.in`. Also moves listing of package data (example and test YAML files) out of `setup.py` into `MANIFEST.in`.