### PR TITLE
Update requirements to use Neo 0.7.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - quantities
   - tqdm
   - pip:
+    - neo>=0.7.2
     - elephant>=0.6.2
     - pylttb
-    - git+https://github.com/NeuralEnsemble/python-neo.git
     - git+https://github.com/NeuralEnsemble/ephyviewer.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 av
 elephant>=0.6.2
 git+https://github.com/NeuralEnsemble/ephyviewer.git
-git+https://github.com/NeuralEnsemble/python-neo.git
+neo>=0.7.2
 numpy
 packaging
 pandas

--- a/setup.py
+++ b/setup.py
@@ -77,20 +77,23 @@ with open('neurotic/version.py', 'w') as f:
 with open('README.rst', 'r') as f:
     README = f.read()
 
-# Unreleased versions of ephyviewer and neo are needed by this package, and the
-# dev version of neo conflicts with the overly restrictive requirements of
-# elephant. The only way around the latter complication is for the user to
-# manually install dependencies using `pip install -r requirements.txt`, which
-# warns about the incompatibility of neo and elephant but doesn't halt.
-# Someday this package may be able to use the specification below, but not
-# before neo releases AxographRawIO in a form compatible with elephant.
+# An unreleased version of ephyviewer is needed by this package. Furthermore,
+# the latest release of neo (0.7.2, needed by this package for AxographRawIO)
+# conflicts with the requirements of the latest release of elephant (0.6.2,
+# needed for rauc and neo API fix) thanks to a bug that has been patched but
+# not released yet (see https://github.com/NeuralEnsemble/elephant/issues/236).
+# The only way around this complication is for the user to manually install
+# dependencies using `pip install -r requirements.txt`, which warns about the
+# incompatibility of neo and elephant but doesn't halt. Someday this package
+# may be able to use the specification below, but not before elephant releases
+# the fixed requirements list and ephyviewer has a release.
 install_requires = [
     # 'av',
     # 'elephant>=0.6.2',
-    # 'ephyviewer @ https://github.com/NeuralEnsemble/ephyviewer/archive/master.tar.gz', # latest version
-    # 'ipywidgets',
-    # 'neo @ https://github.com/NeuralEnsemble/python-neo/archive/master.tar.gz', # TODO require >0.7.1 for AxographRawIO
+    # 'ephyviewer @ https://github.com/NeuralEnsemble/ephyviewer/archive/master.tar.gz', # TODO PyPI disallows "@"
+    # 'neo>=0.7.2',
     # 'numpy',
+    # 'packaging',
     # 'pandas',
     # 'pylttb',
     # 'pyqt5',
@@ -103,12 +106,11 @@ install_requires = [
 # this package depends only on released packages and not development versions.
 # This is because git commands ("git+https://github...") in requirements.txt
 # cannot be understood by setuptools. The "@" notation for specifying urls used
-# above could be placed in an external file like requirements.txt in lieu of
-# git commands, but then `pip install -r requirements.txt` cannot read it. So,
-# to get `pip install neurotic` to install the development version of
-# ephyviewer, it will be necessary to use the "@" notation, and it probably
-# shouldn't be put in an external file with the name requirements.txt because
-# it won't be usable in the normal way with `pip install -r requirements.txt`.
+# above is understood by setuptools but disallowed by PyPI. For these reasons,
+# it may not be possible to get `pip install neurotic` to install the
+# development version of ephyviewer via the normal requirements mechanisms. A
+# hack that opens a subprocess to run `pip install git+https...` might work but
+# is really nefarious.
 # with open('requirements.txt', 'r') as f:
 #     install_requires = f.read()
 


### PR DESCRIPTION
Neo 0.7.2 was released with AxographRawIO (NeuralEnsemble/python-neo#687).

Thanks to a bug in elephant (which has been fixed but not yet released), the latest elephant is technically incompatible with Neo 0.7.2 according to pip (see NeuralEnsemble/elephant#236). Unfortunately neurotic needs both, but the manual installation of requirements recommended in neurotic's README currently works around this.