### PR TITLE
Normalize pre-release version tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ else:
 # If this is not a release version, mark it as a development build/distro and
 # tag it with the git revision number and dirty state.
 if not IS_RELEASED:
-    VERSION += '.dev+git.' + GIT_REVISION[:7]
+    VERSION += '.dev0+git.' + GIT_REVISION[:7]
     if GIT_DIRTY:
         VERSION += '.dirty'
 


### PR DESCRIPTION
The pre-release tag `.dev0` was changed to `.dev` in c764dd5. Since then, the following warning has been raised during installation: `UserWarning: Normalizing 'X.X.X.dev+git...' to 'X.X.X.dev0+git...'`. This commit reverts the tag change to eliminate this warning.