### PR TITLE
Fix Travis CI job for testing Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ install:
 before_script:
     # list versions
     - python --version
+    - python -c "import os, sys; assert sys.version_info[:2] == tuple(map(int, os.environ['TRAVIS_PYTHON_VERSION'].split('.')))[:2]"
     - pip -V
     - pip list
     - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ install:
     - conda config --add channels conda-forge
     - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
     - echo "INSTALLING REQS FOR NEUROTIC"
-    - conda env update -q -n test-environment -f environment.yml
+    - sed "/- python[>]*=/d" environment.yml > environment-without-python-spec.yml
+    - conda env update -q -n test-environment -f environment-without-python-spec.yml
     - source activate test-environment
     - echo "INSTALLING REQS FOR THIS JOB"
     - pip install -r ${JOB_REQS};


### PR DESCRIPTION
The `python=3` spec in `environment.yml` was causing Python to be automatically updating from 3.6 to 3.7, so 3.6 was not being tested at all.