### PR TITLE
Explicitly require Python 3.6 or later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ dist: xenial   # required for Python >= 3.7
 language: python
 python:
     # We don't actually use the Travis Python, but this keeps it organized.
-    # - "3.4" # conda UnsatisfiableError: pandas -> numpy[version='>=1.14.6,<2.0a0'] -> python[version='>=2.7,<2.8.0a0']
-    # - "3.5" # conda never finishes solving environment
     - "3.6"
     - "3.7"
 

--- a/README.rst
+++ b/README.rst
@@ -80,9 +80,10 @@ video synchronization feature!
 Installation
 ------------
 
-**neurotic** requires PyAV_, which is most easily installed from conda-forge_.
-It also does not explicitly list its dependencies within the package metadata
-[1]_, so they must be installed manually.
+**neurotic** requires Python 3.6 or later. It needs PyAV_, which is most easily
+installed from conda-forge_. It also does not explicitly list any of its
+dependencies within the package metadata [1]_, so they must be installed
+manually.
 
 To install PyAV and all other dependencies, use these commands (``pip`` may
 raise a non-fatal error that can be ignored; see [2]_)::

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,9 +3,10 @@
 Installation
 ============
 
-**neurotic** requires PyAV_, which is most easily installed from conda-forge_.
-It also does not explicitly list its dependencies within the package metadata
-[1]_, so they must be installed manually.
+**neurotic** requires Python 3.6 or later. It needs PyAV_, which is most easily
+installed from conda-forge_. It also does not explicitly list any of its
+dependencies within the package metadata [1]_, so they must be installed
+manually.
 
 To install PyAV and all other dependencies, use these commands (``pip`` may
 raise a non-fatal error that can be ignored; see [2]_)::

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - av
   - pip
   - pyqt  # conda-forge's pyqt works better on Travis than pip's PyQt5
-  - python=3
+  - python>=3.6
   - pip:
     - elephant>=0.6.2
     - ephyviewer>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,8 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Scientific/Engineering',
     ],
 )


### PR DESCRIPTION
neurotic uses f-strings and possibly other features introduced in Python 3.6+.