### PR TITLE
Fix launching app with bad metadata arg

### DIFF
--- a/neurotic/gui/standalone.py
+++ b/neurotic/gui/standalone.py
@@ -54,7 +54,7 @@ class MetadataSelectorQt(MetadataSelector, QT.QListWidget):
 
         try:
             MetadataSelector.load(self)
-        except AssertionError as e:
+        except Exception as e:
             print('Bad metadata file!', e)
 
         if self.all_metadata is not None:


### PR DESCRIPTION
Catch all errors such as permission errors and parser errors.