### PR TITLE
Fix README render error on PyPI caused by bad code-block

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,7 @@ including amplitude-threshold spike detection and signal filtering.
 
 The command line interface accepts arguments as well:
 
-.. code-block:: none
+.. code-block::
 
     usage: neurotic [-h] [-V] [--no-lazy] [--thick-traces]
                     [--theme {light,dark,original}]


### PR DESCRIPTION
Fixes ``HTTPError: 400 Client Error: The description failed to render in the default format of reStructuredText.``