### PR TITLE
Fix crash when epoch encoder file contains labels not listed in metadata

### DIFF
--- a/neurotic/gui/config.py
+++ b/neurotic/gui/config.py
@@ -505,9 +505,19 @@ class EphyviewerConfigurator():
 
         if self.is_shown('epoch_encoder') and self.metadata['epoch_encoder_file'] is not None:
 
+            possible_labels = self.metadata['epoch_encoder_possible_labels']
+
+            # append labels found in the epoch encoder file but not in the
+            # epoch_encoder_possible_labels list, preserving the original
+            # ordering of epoch_encoder_possible_labels
+            labels_from_file = [ep.name for ep in seg.epochs if len(ep.times) > 0 and '(from epoch encoder file)' in ep.labels]
+            for label in labels_from_file:
+                if label not in possible_labels:
+                    possible_labels.append(label)
+
             writable_epoch_source = MyWritableEpochSource(
                 filename = abs_path(self.metadata, 'epoch_encoder_file'),
-                possible_labels = self.metadata['epoch_encoder_possible_labels'],
+                possible_labels = possible_labels,
             )
 
             epoch_encoder = ephyviewer.EpochEncoder(source = writable_epoch_source, name = 'epoch encoder')

--- a/neurotic/gui/config.py
+++ b/neurotic/gui/config.py
@@ -275,6 +275,9 @@ class EphyviewerConfigurator():
         win.setWindowTitle(self.metadata['key'])
         win.setWindowIcon(ephyviewer.QT.QIcon(':/neurotic-logo-150.png'))
 
+        # delete on close so that memory and file resources are released
+        win.setAttribute(ephyviewer.QT.WA_DeleteOnClose, True)
+
         ########################################################################
         # PREPARE TRACE PARAMETERS
 

--- a/neurotic/gui/standalone.py
+++ b/neurotic/gui/standalone.py
@@ -346,7 +346,6 @@ class DataExplorer(QT.QMainWindow):
 
             win = ephyviewer_config.create_ephyviewer_window(theme=self.theme, support_increased_line_width=self.support_increased_line_width)
             self.windows.append(win)
-            win.setAttribute(QT.WA_DeleteOnClose, True)
             win.destroyed.connect(lambda qobject, i=len(self.windows)-1: self.free_resources(i))
             win.show()
 

--- a/neurotic/tests/metadata-for-tests.yml
+++ b/neurotic/tests/metadata-for-tests.yml
@@ -1,7 +1,7 @@
 neurotic_config:
     remote_data_root: https://web.gin.g-node.org/jpgill86/neurotic-data/raw/master/tests
 
-events-and-epochs:
+video-jumps-unset:
     data_dir: events-and-epochs
     remote_data_dir: events-and-epochs
     data_file: events_and_epochs.axgx

--- a/neurotic/tests/test_video_sync.py
+++ b/neurotic/tests/test_video_sync.py
@@ -36,7 +36,7 @@ class VideoSyncUnitTest(unittest.TestCase):
 
     def test_video_jumps(self):
         """Test video jump estimation for AxoGraph file with pauses"""
-        dataset = 'events-and-epochs'
+        dataset = 'video-jumps-unset'
         metadata = neurotic.MetadataSelector(file=self.temp_file,
                                              initial_selection=dataset)
         metadata.download('data_file')


### PR DESCRIPTION
Fixes #78