### PR TITLE
Fix Travis job for dev versions conflict between elephant and Neo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ matrix:
                   git+https://github.com/NeuralEnsemble/elephant.git \
                   git+https://github.com/NeuralEnsemble/ephyviewer.git
 
+              # remove elephant's strict requirements for neo
+              # - without this patch, the neurotic CLI script may fail to start
+              - "sed -i '/^Requires-Dist: neo/d' /home/travis/miniconda/envs/test-environment/lib/python3.7/site-packages/elephant-*.dist-info/METADATA"
+
               # list versions
               - python --version
               - python -c "import os, sys; assert sys.version_info[:2] == tuple(map(int, os.environ['TRAVIS_PYTHON_VERSION'].split('.')))[:2]"


### PR DESCRIPTION
Fixes the issue mentioned here: https://github.com/jpgill86/neurotic/pull/91#issuecomment-514291086

Dev neo does not satisfy dev elephant's strict version requirements, though the two are presently otherwise compatible. This caused the Travis job dedicated to testing for future breaking changes to always fail some tests because of this trivial conflict. This commit removes elephant's version requirement for neo after installation so that tests can complete.