### PR TITLE
Add printer-friendly theme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,7 +145,8 @@ The command line interface accepts other arguments too:
 .. code-block::
 
     usage: neurotic [-h] [-V] [--no-lazy] [--thick-traces] [--show-datetime]
-                    [--theme {light,dark,original}] [--launch-example-notebook]
+                    [--theme {light,dark,original,printer-friendly}]
+                    [--launch-example-notebook]
                     [file] [dataset]
 
     neurotic lets you curate, visualize, annotate, and share your behavioral ephys
@@ -168,7 +169,7 @@ The command line interface accepts other arguments too:
       --show-datetime       display the real-world date and time, which may be
                             inaccurate if the data file includes pauses (default:
                             do not display)
-      --theme {light,dark,original}
+      --theme {light,dark,original,printer-friendly}
                             a color theme for the GUI (default: light)
       --launch-example-notebook
                             launch Jupyter with an example notebook instead of

--- a/neurotic/gui/config.py
+++ b/neurotic/gui/config.py
@@ -81,6 +81,12 @@ class EphyviewerConfigurator():
             'vline_color': '#FFFFFFAA', # transparent white
             'label_fill_color': '#222222DD', # transparent dark gray
         }
+        self.themes['printer-friendly'] = {
+            'cmap': 'Dark2', # dark traces
+            'background_color': '#FFFFFF', # white
+            'vline_color': '#000000AA', # transparent black
+            'label_fill_color': '#DDDDDDDD', # transparent light gray
+        }
 
         # hide and disable viewers for which inputs are missing
         if not self.rauc_sigs:

--- a/neurotic/gui/standalone.py
+++ b/neurotic/gui/standalone.py
@@ -164,12 +164,19 @@ class MainWindow(QT.QMainWindow):
         do_select_original_theme.triggered.connect(self.select_original_theme)
         self.theme_group.addAction(do_select_original_theme)
 
+        do_select_printer_friendly_theme = self.theme_menu.addAction('&Printer-friendly theme')
+        do_select_printer_friendly_theme.setCheckable(True)
+        do_select_printer_friendly_theme.triggered.connect(self.select_printer_friendly_theme)
+        self.theme_group.addAction(do_select_printer_friendly_theme)
+
         if self.theme == 'light':
             do_select_light_theme.setChecked(True)
         elif self.theme == 'dark':
             do_select_dark_theme.setChecked(True)
         elif self.theme == 'original':
             do_select_original_theme.setChecked(True)
+        elif self.theme == 'printer-friendly':
+            do_select_printer_friendly_theme.setChecked(True)
         else:
             raise ValueError('theme "{}" is unrecognized'.format(self.theme))
 
@@ -362,6 +369,9 @@ class MainWindow(QT.QMainWindow):
 
     def select_original_theme(self):
         self.theme = 'original'
+
+    def select_printer_friendly_theme(self):
+        self.theme = 'printer-friendly'
 
     def free_resources(self, i):
         """

--- a/neurotic/scripts.py
+++ b/neurotic/scripts.py
@@ -45,7 +45,8 @@ def parse_args(argv):
                         help='display the real-world date and time, which ' \
                              'may be inaccurate if the data file includes ' \
                              'pauses (default: do not display)')
-    parser.add_argument('--theme', choices=['light', 'dark', 'original'],
+    parser.add_argument('--theme', choices=['light', 'dark', 'original',
+                                            'printer-friendly'],
                         default='light', help='a color theme for the GUI ' \
                                               '(default: light)')
 

--- a/neurotic/tests/test_cli.py
+++ b/neurotic/tests/test_cli.py
@@ -124,6 +124,11 @@ class CLITestCase(unittest.TestCase):
         win = neurotic.win_from_args(args)
         self.assertEqual(win.theme, 'original', 'unexpected theme')
 
+        argv = ['neurotic', '--theme', 'printer-friendly']
+        args = neurotic.parse_args(argv)
+        win = neurotic.win_from_args(args)
+        self.assertEqual(win.theme, 'printer-friendly', 'unexpected theme')
+
     def test_file(self):
         """Test that metadata file can be set"""
         argv = ['neurotic', self.temp_file]


### PR DESCRIPTION
Like the light theme, but uses white backgrounds so that screenshots can be printed using less ink.