### PR TITLE
Add Travis CI workaround for elephant's incompatibility with Neo 0.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,12 @@ install:
 
     # install package
     - echo "INSTALLING NEUROTIC"
-    - python setup.py install
+    # - python setup.py install
+
+    # temporary, very dirty workaround for elephant incompatibility with neo 0.8 -- REMOVE LATER
+    - pip install --no-warn-conflicts .  # will write version.py to a temp dir, so manually create it below
+    - echo version=\'unknown\' > neurotic/version.py
+    - echo git_revision=\'unknown\' >> neurotic/version.py
 
 before_script:
     # list versions

--- a/neurotic/datasets/data.py
+++ b/neurotic/datasets/data.py
@@ -93,7 +93,7 @@ def _read_data_file(metadata, lazy=False, signal_group_mode='split-all'):
     # load all objects except analog signals
     if lazy:
 
-        if version.parse(neo.__version__) >= version.parse('0.8.0.dev'):  # Neo >= 0.8.0 has proxy objects with load method
+        if version.parse(neo.__version__) >= version.parse('0.8.0'):  # Neo >= 0.8.0 has proxy objects with load method
 
             for i in range(len(blk.segments[0].epochs)):
                 epoch = blk.segments[0].epochs[i]
@@ -407,7 +407,7 @@ def _create_neo_spike_trains_from_dataframe(dataframe, metadata, t_start, t_stop
 
 def _apply_filters(metadata, blk):
     """
-    Apply filters specified in ``metadata`` the the signals in ``blk`` using
+    Apply filters specified in ``metadata`` to the signals in ``blk`` using
     :func:`elephant.signal_processing.butter`.
     """
 


### PR DESCRIPTION
See NeuralEnsemble/elephant#253 for a description of the issue. This patch gets around the error that occurs during building on the Travis CI server.

Users will still encounter this warning during installation: ``ERROR: elephant 0.6.3 has requirement neo<0.8.0,>=0.7.1, but you'll have neo 0.8.0 which is incompatible``. They _should_ be able to ignore it.