### PR TITLE
Update requirements for datetime and warnings about inaccuracy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,8 +167,8 @@ The command line interface accepts other arguments too:
                             a performance cost (default: disable thick line
                             support)
       --show-datetime       display the real-world date and time, which may be
-                            inaccurate if the data file includes pauses (default:
-                            do not display)
+                            inaccurate depending on file type and acquisition
+                            software (default: do not display)
       --theme {light,dark,original,printer-friendly}
                             a color theme for the GUI (default: light)
       --launch-example-notebook

--- a/neurotic/gui/standalone.py
+++ b/neurotic/gui/standalone.py
@@ -54,9 +54,9 @@ class MainWindow(QT.QMainWindow):
         self.support_increased_line_width = support_increased_line_width
 
         # show_datetime=True will display the real-world date and time next to
-        # the in-file time, but this may be inaccurate if data acquisition was
-        # paused and continued after some delay (e.g. in the same situations
-        # that video_jumps may be necessary for synchronization)
+        # the in-file time, but this may be inaccurate for several reasons,
+        # e.g. if data acquisition was paused and continued after some delay or
+        # if an AxoGraph chart was not started immediately after creation
         self.show_datetime = show_datetime
 
         # windows are appended to this list so that they persist after the
@@ -140,7 +140,7 @@ class MainWindow(QT.QMainWindow):
         do_toggle_support_increased_line_width.triggered.connect(self.toggle_support_increased_line_width)
         self.options_menu.addAction(do_toggle_support_increased_line_width)
 
-        do_toggle_show_datetime = QT.QAction('&Display date and time (inaccurate if DAQ was paused)', self)
+        do_toggle_show_datetime = QT.QAction('&Display date and time (potentially inaccurate)', self)
         do_toggle_show_datetime.setCheckable(True)
         do_toggle_show_datetime.setChecked(self.show_datetime)
         do_toggle_show_datetime.triggered.connect(self.toggle_show_datetime)

--- a/neurotic/scripts.py
+++ b/neurotic/scripts.py
@@ -43,8 +43,8 @@ def parse_args(argv):
                              'disable thick line support)')
     parser.add_argument('--show-datetime', action='store_true', dest='datetime',
                         help='display the real-world date and time, which ' \
-                             'may be inaccurate if the data file includes ' \
-                             'pauses (default: do not display)')
+                             'may be inaccurate depending on file type and ' \
+                             'acquisition software (default: do not display)')
     parser.add_argument('--theme', choices=['light', 'dark', 'original',
                                             'printer-friendly'],
                         default='light', help='a color theme for the GUI ' \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # av  # required but typically not installable via pip, try `conda install -c conda-forge av`
 elephant>=0.6.3
-ephyviewer>=1.1.0
+ephyviewer>=1.2.0
 neo>=0.7.2
 numpy
 packaging


### PR DESCRIPTION
Following release of ephyviewer 1.2.0, it is now possible to require it for ``datetime_format``.

Also, I have discovered at least one more way (other than pauses during acquisition) by which the datetime stored in an AxoGraph file may be inaccurate: if the chart was created with "New chart" and not immediately run with "Run chart", the delay will introduce inaccuracy. The time when "New chart" was clicked is stored in the file, not when "Run chart" was clicked. Warnings and comments have been updated to reflect this.