### PR TITLE
Add metadata parameters io_class and io_args

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -3,8 +3,8 @@
 Configuring Metadata
 ====================
 
-To load your data with **neurotic**, you must organized them in one or more
-YAML files, called *metadata files*.
+To load your data with **neurotic**, you must organize them in one or more YAML
+files, called *metadata files*.
 
 YAML files are very sensitive to punctuation and indentation, so mind those
 details carefully! Importantly, the tab character cannot be used for
@@ -218,6 +218,45 @@ For example:
 
     my favorite dataset:
         # dataset details here
+
+.. _config-metadata-neo-io:
+
+Data Reader (Neo) Settings
+--------------------------
+
+The electrophysiology file specified by ``data_file`` is read using Neo_, which
+supports many file types. A complete list of the implemented formats can be
+found here: :mod:`neo.io`.
+
+By default, **neurotic** will use the file extension of ``data_file`` to guess
+the file format and choose the appropriate Neo IO class for reading it. If the
+guess fails, you can force **neurotic** to use a different class by specifying
+the class name with the ``io_class`` parameter (all available classes are
+listed here: :mod:`neo.io`).
+
+Some Neo IO classes accept additional arguments beyond just a filename (see the
+Neo docs for details: :mod:`neo.io`). You can specify these arguments in your
+metadata using the ``io_args`` parameter.
+
+For example, suppose you have data stored in a plain text file that is missing
+a file extension. The :class:`neo.io.AsciiSignalIO` class can read plain text
+files, but you must specify this manually using ``io_class`` because the
+extension is missing. You could do this and pass in supported arguments in the
+following way:
+
+.. code-block:: yaml
+
+    my favorite dataset:
+        data_file: plain_text_file_without_file_extension
+
+        io_class: AsciiSignalIO
+
+        io_args:
+            skiprows: 1  # skip header
+            delimiter: ' '  # space-delimited
+            t_start: 5  # sec
+            sampling_rate: 1000  # Hz
+            units: mV
 
 .. _config-metadata-video:
 

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -252,10 +252,10 @@ following way:
         io_class: AsciiSignalIO
 
         io_args:
-            skiprows: 1  # skip header
-            delimiter: ' '  # space-delimited
-            t_start: 5  # sec
-            sampling_rate: 1000  # Hz
+            skiprows: 1 # skip header
+            delimiter: ' ' # space-delimited
+            t_start: 5 # sec
+            sampling_rate: 1000 # Hz
             units: mV
 
 .. _config-metadata-video:

--- a/neurotic/datasets/data.py
+++ b/neurotic/datasets/data.py
@@ -6,7 +6,6 @@ dataset from selected metadata.
 .. autofunction:: load_dataset
 """
 
-import inspect
 from packaging import version
 import numpy as np
 import pandas as pd

--- a/neurotic/datasets/data.py
+++ b/neurotic/datasets/data.py
@@ -6,6 +6,7 @@ dataset from selected metadata.
 .. autofunction:: load_dataset
 """
 
+import inspect
 from packaging import version
 import numpy as np
 import pandas as pd
@@ -76,19 +77,66 @@ def load_dataset(metadata, lazy=False, signal_group_mode='split-all', filter_eve
 
     return blk
 
-def _read_data_file(metadata, lazy=False, signal_group_mode='split-all'):
+def _get_io(metadata):
     """
-    Read in the ``data_file`` given in ``metadata`` using an automatically
-    detected :mod:`neo.io` class if ``lazy=False`` or a :mod:`neo.rawio` class
-    if ``lazy=True``. If ``lazy=True``, manually load epochs, events, and spike
-    trains, but not signals. Return a Neo :class:`Block <neo.core.Block>`.
+    Return a :mod:`neo.io` object for reading the ``data_file`` in
+    ``metadata``. An appropriate :mod:`neo.io` class is typically determined
+    automatically from the file extension, but this can be overridden with the
+    optional ``io_class`` metadata parameter. Arbitrary arguments can be passed
+    to the :mod:`neo.io` class using the optional ``io_args`` metadata
+    parameter.
     """
 
-    # read in the electrophysiology data
-    # - signal_group_mode='split-all' ensures every channel gets its own
-    #   AnalogSignal, which is important for indexing in EphyviewerConfigurator
-    io = neo.io.get_io(_abs_path(metadata, 'data_file'))
-    blk = io.read_block(lazy=lazy, signal_group_mode=signal_group_mode)
+    # prepare arguments for instantiating a Neo IO class
+    if metadata['io_args'] is not None:
+        io_args = metadata['io_args'].copy()
+        if 'sampling_rate' in io_args:
+            # AsciiSignalIO's sampling_rate must be a Quantity
+            io_args['sampling_rate'] *= pq.Hz
+    else:
+        io_args = {}
+
+    if metadata['io_class'] is None:
+        # detect the class automatically using the file extension
+        io = neo.io.get_io(_abs_path(metadata, 'data_file'), **io_args)
+
+    else:
+        # use a user-specified class
+        io_list = [io.__name__ for io in neo.io.iolist]
+        if metadata['io_class'] not in io_list:
+            raise ValueError(f"specified io_class \"{metadata['io_class']}\" was not found in neo.io.iolist: {io_list}")
+        io_class_index = io_list.index(metadata['io_class'])
+        io_class = neo.io.iolist[io_class_index]
+        io = io_class(_abs_path(metadata, 'data_file'), **io_args)
+
+    return io
+
+def _read_data_file(metadata, lazy=False, signal_group_mode='split-all'):
+    """
+    Read in the ``data_file`` given in ``metadata`` using a :mod:`neo.io`
+    class. Lazy-loading is used for signals if both ``lazy=True`` and the data
+    file type is supported by a :mod:`neo.rawio` class; otherwise, signals are
+    fully loaded. Lazy-loading is never used for epochs, events, and spike
+    trains contained in the data file; these are always fully loaded. Returns a
+    Neo :class:`Block <neo.core.Block>`.
+    """
+
+    # get a Neo IO object appropriate for the data file type
+    io = _get_io(metadata)
+
+    # force lazy=False if lazy is not supported by the reader class
+    if lazy and not io.support_lazy:
+        lazy = False
+        print(f'NOTE: Not reading signals in lazy mode because Neo\'s {io.__class__.__name__} reader does not support it.')
+
+    if type(io) is not neo.io.AsciiSignalIO:
+        # - signal_group_mode='split-all' is the default because this ensures
+        #   every channel gets its own AnalogSignal, which is important for
+        #   indexing in EphyviewerConfigurator
+        blk = io.read_block(lazy=lazy, signal_group_mode=signal_group_mode)
+    else:
+        # AsciiSignalIO.read_block does not have the signal_group_mode argument
+        blk = io.read_block(lazy=lazy)
 
     # load all objects except analog signals
     if lazy:

--- a/neurotic/datasets/data.py
+++ b/neurotic/datasets/data.py
@@ -97,8 +97,19 @@ def _get_io(metadata):
         io_args = {}
 
     if metadata['io_class'] is None:
-        # detect the class automatically using the file extension
-        io = neo.io.get_io(_abs_path(metadata, 'data_file'), **io_args)
+        try:
+            # detect the class automatically using the file extension
+            io = neo.io.get_io(_abs_path(metadata, 'data_file'), **io_args)
+        except IOError as e:
+            if e.args[0].startswith('File extension'):
+                # provide a useful error message when format detection fails
+                raise IOError("Could not find an appropriate neo.io class " \
+                              f"for data_file \"{metadata['data_file']}\". " \
+                              "Try specifying one in your metadata using " \
+                              "the io_class parameter.")
+            else:
+                # something else has gone wrong, like the file not being found
+                raise e
 
     else:
         # use a user-specified class

--- a/neurotic/datasets/metadata.py
+++ b/neurotic/datasets/metadata.py
@@ -307,6 +307,15 @@ def _defaults_for_key(key):
         # - path relative to data_dir and remote_data_dir
         'data_file': None,
 
+        # the name of a Neo IO class
+        # - this parameter is optional and exists for overriding the IO class
+        #   determined automatically from the data file's extension
+        'io_class': None,
+
+        # arguments for the Neo IO class
+        # - e.g. for AsciiSignalIO, {'delimiter': ',', 'sampling_rate': 1000, 'units': 'mV'}
+        'io_args': None,
+
         # digital filters to apply before analysis and plotting
         # 0 <= highpass <= lowpass < sample_rate/2
         # - e.g. [{'channel': 'Channel A', 'highpass': 0, 'lowpass': 50}, ...]

--- a/neurotic/tests/metadata-for-tests.yml
+++ b/neurotic/tests/metadata-for-tests.yml
@@ -14,3 +14,59 @@ video-jumps-unset:
         - channel: Clock
           units: V
           ylim: [-0.1, 5.1]
+
+missing-extension-without-io_class:
+    description: (should error)
+
+    data_dir: missing-extension
+    remote_data_dir: missing-extension
+    data_file: events_and_epochs_axgx_no_ext
+
+    plots:
+        - channel: "Analog Input #5"
+          units: mV
+          ylim: [-5, 0]
+        - channel: Clock
+          units: V
+          ylim: [-0.1, 5.1]
+
+missing-extension-with-io_class:
+    data_dir: missing-extension
+    remote_data_dir: missing-extension
+    data_file: events_and_epochs_axgx_no_ext
+
+    io_class: AxographIO
+
+    plots:
+        - channel: "Analog Input #5"
+          units: mV
+          ylim: [-5, 0]
+        - channel: Clock
+          units: V
+          ylim: [-0.1, 5.1]
+
+plain-text-axograph:
+    data_dir: plain-text-axograph
+    remote_data_dir: plain-text-axograph
+    data_file: plain_text.axgt
+
+    io_class: AsciiSignalIO
+    io_args:
+        skiprows: 1 # skip header
+        usecols: [1, 2] # drop time column
+        sampling_rate: 5000 # Hz
+        t_start: 0.0002 # sec
+        # time column cannot be used because AsciiSignalIO imports data with
+        # only 32-bit precision, then judges the resulting variability between
+        # times caused by numerical imprecision to be too great, and so it
+        # creates IrregularlySampledSignals instead of AnalogSignals
+
+    plots:
+        - channel: Column 0
+          ylabel: "Analog Input #5"
+          units: mV
+          ylim: [-5, 0]
+        - channel: Column 1
+          ylabel: Clock
+          units: V
+          ylim: [-0.1, 5.1]

--- a/neurotic/tests/test_neo_io.py
+++ b/neurotic/tests/test_neo_io.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for Neo IO features
+"""
+
+import pkg_resources
+import tempfile
+import shutil
+import gc
+import unittest
+import logging
+
+import neurotic
+
+logger = logging.getLogger(__name__)
+
+class NeoIOUnitTest(unittest.TestCase):
+
+    def setUp(self):
+        self.file = pkg_resources.resource_filename(
+            'neurotic.tests', 'metadata-for-tests.yml')
+
+        # make a copy of the metadata file in a temp directory
+        self.temp_dir = tempfile.TemporaryDirectory(prefix='neurotic-')
+        self.temp_file = shutil.copy(self.file, self.temp_dir.name)
+
+    def tearDown(self):
+        # clean up references to proxy objects which keep files locked
+        gc.collect()
+
+        # remove the temp directory
+        self.temp_dir.cleanup()
+
+    def test_missing_extension_error(self):
+        """Test error is raised when file extension and io_class are missing"""
+        dataset = 'missing-extension-without-io_class'
+        metadata = neurotic.MetadataSelector(file=self.temp_file,
+                                             initial_selection=dataset)
+        metadata.download('data_file')
+
+        with self.assertRaisesRegex(IOError, 'Could not find an appropriate neo.io class .*'):
+            blk = neurotic.load_dataset(metadata=metadata, lazy=True)
+
+    def test_missing_extension_io_class(self):
+        """Test io_class works for data file with missing extension"""
+        dataset = 'missing-extension-with-io_class'
+        metadata = neurotic.MetadataSelector(file=self.temp_file,
+                                             initial_selection=dataset)
+        metadata.download('data_file')
+
+        blk = neurotic.load_dataset(metadata=metadata, lazy=True)
+        assert(blk)
+
+    def test_plain_text_axograph(self):
+        """Test reading a plain text AXGT file using io_class and io_args"""
+        dataset = 'plain-text-axograph'
+        metadata = neurotic.MetadataSelector(file=self.temp_file,
+                                             initial_selection=dataset)
+        metadata.download('data_file')
+
+        blk = neurotic.load_dataset(metadata=metadata, lazy=False)
+        assert(blk)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The new metadata parameters provide users with greater control over how data files are read by Neo (closes #133).

Also, attempting to lazy-load a data file type that does not have a supported Neo RawIO will no longer fail with an error. Instead, non-lazy loading will be used after a warning is printed.