### PR TITLE
Unmask FileNotFoundError when local data file is missing

### DIFF
--- a/neurotic/datasets/data.py
+++ b/neurotic/datasets/data.py
@@ -101,7 +101,7 @@ def _get_io(metadata):
             # detect the class automatically using the file extension
             io = neo.io.get_io(_abs_path(metadata, 'data_file'), **io_args)
         except IOError as e:
-            if e.args[0].startswith('File extension'):
+            if len(e.args) > 0 and type(e.args[0]) is str and e.args[0].startswith('File extension'):
                 # provide a useful error message when format detection fails
                 raise IOError("Could not find an appropriate neo.io class " \
                               f"for data_file \"{metadata['data_file']}\". " \

--- a/neurotic/tests/test_neo_io.py
+++ b/neurotic/tests/test_neo_io.py
@@ -31,6 +31,16 @@ class NeoIOUnitTest(unittest.TestCase):
         # remove the temp directory
         self.temp_dir.cleanup()
 
+    def test_missing_data_file(self):
+        """Test error is raised when data file is not found locally"""
+        dataset = 'video-jumps-unset'
+        metadata = neurotic.MetadataSelector(file=self.temp_file,
+                                             initial_selection=dataset)
+        # intentionally skipping downloading data file
+
+        with self.assertRaises(FileNotFoundError):
+            blk = neurotic.load_dataset(metadata=metadata, lazy=True)
+
     def test_missing_extension_error(self):
         """Test error is raised when file extension and io_class are missing"""
         dataset = 'missing-extension-without-io_class'


### PR DESCRIPTION
I'm first adding a test that is expected to fail thanks to recent changes that obfuscate the FileNotFoundError...