### PR TITLE
Add color option for amplitude_discriminators

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -450,7 +450,9 @@ the basis of amplitude alone. Note that amplitude discriminators are only
 applied if fast loading is off (``lazy=False``).
 
 Detected spikes are indicated on the signals with markers, and spike trains are
-displayed in a raster plot.
+displayed in a raster plot. Optionally, a color may be specified for an
+amplitude discriminator using a single letter color code (e.g., ``'b'`` for
+blue or ``'k'`` for black) or a hexadecimal color code (e.g., ``'1b9e77'``).
 
 In addition to restricting spike detection for a given unit to an amplitude
 window, detection can also be limited in time to overlap with epochs with a
@@ -471,12 +473,14 @@ for each amplitude discriminator.
               channel: Extracellular
               units: uV
               amplitude: [50, 150]
+              color: r
 
             - name: Unit 2
               channel: Extracellular
               units: uV
               amplitude: [20, 50]
               epoch: Unit 2 activity
+              color: 'e6ab02'
 
 Here two units are detected on the same channel with different amplitude
 windows. Any peaks between 50 and 150 microvolts on the "Extracellular" channel

--- a/neurotic/datasets/metadata.py
+++ b/neurotic/datasets/metadata.py
@@ -332,8 +332,8 @@ def _defaults_for_key(key):
         # list of labels for epoch encoder
         'epoch_encoder_possible_labels': ['Type 1', 'Type 2', 'Type 3'],
 
-        # list of dicts giving name, channel, units, amplitude window, epoch window for each unit
-        # - e.g. [{'name': 'Unit X', 'channel': 'Channel A', 'units': 'uV', 'amplitude': [75, 150], 'epoch': 'Type 1'}, ...]
+        # list of dicts giving name, channel, units, amplitude window, epoch window, color for each unit
+        # - e.g. [{'name': 'Unit X', 'channel': 'Channel A', 'units': 'uV', 'amplitude': [75, 150], 'epoch': 'Type 1', 'color': 'ff0000'}, ...]
         'amplitude_discriminators': None,
 
         # list of dicts giving name of a spiketrain, start and stop firing rate

--- a/neurotic/example/metadata.yml
+++ b/neurotic/example/metadata.yml
@@ -50,17 +50,20 @@ example dataset:
           channel: BN2
           units: uV
           amplitude: [50, 150]
+          color: '1b9e77'
 
         - name: B38
           channel: BN2
           units: uV
           amplitude: [17, 26]
           epoch: B38 activity
+          color: '7570b3'
 
         - name: B4/B5
           channel: BN3
           units: uV
           amplitude: [85, 200]
+          color: 'e6ab02'
 
     burst_detectors:  # used only if fast loading is off (lazy=False)
 


### PR DESCRIPTION
Color is applied both to scatter markers in the TraceViewer and to raster plot ticks in the SpikeTrainViewer.