### PR TITLE
Log fatal errors in standalone app instead of crashing

### DIFF
--- a/neurotic/datasets/download.py
+++ b/neurotic/datasets/download.py
@@ -80,28 +80,28 @@ def download(url, local_file, overwrite_existing=False, show_progress=True, byte
 
             if error_code == 404:
                 # not found
-                logger.critical(f'Skipping {os.path.basename(local_file)} (not found on server)')
+                logger.error(f'Skipping {os.path.basename(local_file)} (not found on server)')
                 return
 
             elif error_code == 550:
                 # no such file or folder, or permission denied
-                logger.critical(f'Skipping {os.path.basename(local_file)} (not found on server, or user is unauthorized)')
+                logger.error(f'Skipping {os.path.basename(local_file)} (not found on server, or user is unauthorized)')
                 return
 
             elif error_code == 10060:
                 # timeout
                 hostname = urllib.parse.urlparse(url).hostname
-                logger.critical(f'Skipping {os.path.basename(local_file)} (timed out when connecting to {hostname})')
+                logger.error(f'Skipping {os.path.basename(local_file)} (timed out when connecting to {hostname})')
                 return
 
             elif error_code == 11001:
                 # could not reach server or resolve hostname
                 hostname = urllib.parse.urlparse(url).hostname
-                logger.critical(f'Skipping {os.path.basename(local_file)} (cannot connect to {hostname})')
+                logger.error(f'Skipping {os.path.basename(local_file)} (cannot connect to {hostname})')
                 return
 
             else:
-                logger.critical(f'Encountered a problem: {error}')
+                logger.error(f'Encountered a problem: {error}')
                 return
 
 
@@ -253,7 +253,7 @@ def _authenticate(url):
                     raise error
 
         if bad_login_attempts >= _max_bad_login_attempts:
-            logger.critical('Unauthorized: Aborting login')
+            logger.error('Unauthorized: Aborting login')
             return False
         else:
             if bad_login_attempts == 0:
@@ -269,7 +269,7 @@ def _authenticate(url):
             host, port = urllib.parse.splitport(netloc)
             user = input(f'User name on {host}: ')
             if not user:
-                logger.critical('No user given, aborting login')
+                logger.error('No user given, aborting login')
                 return False
             passwd = getpass('Password: ')
             handler.add_password(None, netloc, user, passwd)

--- a/neurotic/datasets/metadata.py
+++ b/neurotic/datasets/metadata.py
@@ -99,7 +99,7 @@ class MetadataSelector():
         Select a metadata set.
         """
         if self.all_metadata is None:
-            logger.critical('Load metadata before selecting')
+            logger.error('Load metadata before selecting')
         elif selection not in self.all_metadata:
             raise ValueError('{} was not found in {}'.format(selection, self.file))
         else:
@@ -451,7 +451,7 @@ def _download_file(metadata, file, **kwargs):
     """
 
     if not _is_url(metadata['remote_data_dir']):
-        logger.critical('metadata[remote_data_dir] is not a full URL')
+        logger.error('metadata[remote_data_dir] is not a full URL')
         return
 
     if metadata[file]:
@@ -473,7 +473,7 @@ def _download_all_data_files(metadata, **kwargs):
     """
 
     if not _is_url(metadata['remote_data_dir']):
-        logger.critical('metadata[remote_data_dir] is not a full URL')
+        logger.error('metadata[remote_data_dir] is not a full URL')
         return
 
     for file in [k for k in metadata if k.endswith('_file')]:

--- a/neurotic/gui/config.py
+++ b/neurotic/gui/config.py
@@ -188,7 +188,7 @@ class EphyviewerConfigurator():
             else:
                 logger.warning(self.viewer_settings[name]['reason'])
         else:
-            logger.critical(f'"{name}" is not a viewer in viewer_settings')
+            logger.error(f'"{name}" is not a viewer in viewer_settings')
 
     def hide(self, name):
         """
@@ -197,7 +197,7 @@ class EphyviewerConfigurator():
         if name in self.viewer_settings:
             self.viewer_settings[name]['show'] = False
         else:
-            logger.critical(f'"{name}" is not a viewer in viewer_settings')
+            logger.error(f'"{name}" is not a viewer in viewer_settings')
 
     def show_all(self):
         """

--- a/neurotic/gui/standalone.py
+++ b/neurotic/gui/standalone.py
@@ -296,6 +296,10 @@ class MainWindow(QT.QMainWindow):
             logger.critical('Some files were not found locally and may need '
                            f'to be downloaded: {e}')
 
+        except Exception:
+
+            logger.exception('Encountered a fatal error. Traceback will be written to log file.')
+
     def view_log_file(self):
         """
         Open the log file in an editor.

--- a/neurotic/gui/standalone.py
+++ b/neurotic/gui/standalone.py
@@ -108,7 +108,7 @@ class MainWindow(QT.QMainWindow):
             try:
                 self.metadata_selector.setCurrentRow(list(self.metadata_selector.all_metadata).index(initial_selection))
             except (TypeError, ValueError) as e:
-                logger.critical(f'Bad dataset key, will ignore: {e}')
+                logger.error(f'Bad dataset key, will ignore: {e}')
 
     def create_menus(self):
         """
@@ -228,7 +228,7 @@ class MainWindow(QT.QMainWindow):
         try:
             open_path_with_default_program(self.metadata_selector.file)
         except FileNotFoundError as e:
-            logger.critical(f'The metadata file was not found: {e}')
+            logger.error(f'The metadata file was not found: {e}')
             return
 
     def download_files(self):
@@ -261,9 +261,9 @@ class MainWindow(QT.QMainWindow):
         try:
             open_path_with_default_program(self.metadata_selector['data_dir'])
         except FileNotFoundError as e:
-            logger.critical('The directory for the selected dataset was not '
-                           'found locally, perhaps because it does not exist '
-                           f'yet: {e}')
+            logger.error('The directory for the selected dataset was not '
+                         'found locally, perhaps because it does not exist '
+                         f'yet: {e}')
 
     def launch(self):
         """
@@ -293,8 +293,8 @@ class MainWindow(QT.QMainWindow):
 
         except FileNotFoundError as e:
 
-            logger.critical('Some files were not found locally and may need '
-                           f'to be downloaded: {e}')
+            logger.error('Some files were not found locally and may need to '
+                         f'be downloaded: {e}')
 
         except Exception:
 
@@ -308,7 +308,7 @@ class MainWindow(QT.QMainWindow):
         try:
             open_path_with_default_program(log_file)
         except FileNotFoundError as e:
-            logger.critical(f'The log file was not found: {e}')
+            logger.error(f'The log file was not found: {e}')
             return
 
     def show_about(self):
@@ -448,7 +448,7 @@ class _MetadataSelectorQt(MetadataSelector, QT.QListWidget):
         try:
             MetadataSelector.load(self)
         except Exception as e:
-            logger.critical(f'Bad metadata file: {e}')
+            logger.error(f'Bad metadata file\n{e}')
 
         if self.all_metadata is not None:
 

--- a/neurotic/scripts.py
+++ b/neurotic/scripts.py
@@ -88,8 +88,8 @@ def launch_example_notebook():
         out = subprocess.Popen(['jupyter', 'notebook', '--version'],
                                stdout=subprocess.PIPE).communicate()[0]
     except FileNotFoundError as e:
-        logger.critical('Unable to verify Jupyter is installed using "jupyter '
-                        'notebook --version". Is it installed?')
+        logger.error('Unable to verify Jupyter is installed using "jupyter '
+                     'notebook --version". Is it installed?')
 
     if out:
         # run Jupyter on the example notebook
@@ -97,7 +97,7 @@ def launch_example_notebook():
             out = subprocess.Popen(['jupyter', 'notebook', path],
                                    stdout=subprocess.PIPE).communicate()[0]
         except FileNotFoundError as e:
-            logger.critical(f'Unable to locate the example notebook at {path}')
+            logger.error(f'Unable to locate the example notebook at {path}')
 
 def main():
     """


### PR DESCRIPTION
If a fatal exception was raised when launching a dataset in the standalone app, neurotic would previously simply crash. After this change, the exception traceback is recorded in the log file and streamed to stderr, but the app should not crash.

Closes #175 