### PR TITLE
Add more color options

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -341,7 +341,9 @@ Plot Parameters
 ---------------
 
 Use the ``plots`` parameter to specify which signal channels from ``data_file``
-you want plotted and how to scale them.
+you want plotted and how to scale them. Optionally, a color may be specified
+for channels using a single letter color code (e.g., ``'b'`` for blue or
+``'k'`` for black) or a hexadecimal color code (e.g., ``'1b9e77'``).
 
 Consider the following example, and notice the use of hyphens and indentation
 for each channel.
@@ -357,11 +359,13 @@ for each channel.
               ylabel: Buccal nerve 2 (BN2)
               units: uV
               ylim: [-150, 150]
+              color: r
 
             - channel: Intracellular
               ylabel: B3 neuron
               units: mV
               ylim: [-100, 50]
+              color: '666666'
 
             - channel: Force
               units: mN
@@ -615,7 +619,8 @@ The signal is then rectified (absolute value) and divided into non-overlapping
 bins of fixed duration. Finally, the integral is calculated within each bin.
 The result is a new time series that represents the overall activity of the
 original signal. RAUC time series are plotted separately from the original
-signals in a second tab.
+signals in a second tab. Colors are inherited from ``plots``, if they are
+provided there.
 
 The choice of baseline is controlled by the ``rauc_baseline`` metadata
 parameter, which may have the value ``None`` (default), ``'mean'``, or

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -564,7 +564,8 @@ burst detection algorithm that relies on firing rate thresholds can be run to
 detect periods of intense activity. Note that burst detectors are only applied
 if fast loading is off (``lazy=False``).
 
-Detected bursts are plotted as epochs.
+Detected bursts are plotted as epochs. Colors are inherited from
+``amplitude_discriminators``, if they are provided there.
 
 Burst detectors are specified in metadata like this:
 

--- a/neurotic/datasets/metadata.py
+++ b/neurotic/datasets/metadata.py
@@ -388,7 +388,7 @@ def _defaults_for_key(key):
         'video_rate_correction': None,
 
         # list the channels in the order they should be plotted
-        # - e.g. [{'channel': 'Channel A', 'ylabel': 'My channel', 'ylim': [-120, 120], 'units': 'uV'}, ...]
+        # - e.g. [{'channel': 'Channel A', 'ylabel': 'My channel', 'ylim': [-120, 120], 'units': 'uV', 'color': 'ff0000'}, ...]
         'plots': None,
 
         # amount of time in seconds to plot initially

--- a/neurotic/gui/config.py
+++ b/neurotic/gui/config.py
@@ -273,6 +273,13 @@ class EphyviewerConfigurator():
         win.setAttribute(ephyviewer.QT.WA_DeleteOnClose, True)
 
         ########################################################################
+        # COLORS
+
+        unit_colors = {}
+        if self.metadata['amplitude_discriminators'] is not None:
+            unit_colors = {d['name']: d['color'] for d in self.metadata['amplitude_discriminators'] if 'color' in d}
+
+        ########################################################################
         # TRACES WITH SCATTER PLOTS
 
         _set_defaults_for_plots(self.metadata, self.blk)
@@ -349,9 +356,6 @@ class EphyviewerConfigurator():
                 # choose reasonable default colors (done above), and only then
                 # override colors for spike trains that have been explicitly
                 # set in amplitude_discriminators (done here)
-                unit_colors = {}
-                if self.metadata['amplitude_discriminators'] is not None:
-                    unit_colors = {d['name']: d['color'] for d in self.metadata['amplitude_discriminators'] if 'color' in d}
                 sources['signal'][-1].scatter_colors.update(unit_colors)
 
             # useOpenGL=True eliminates the extremely poor performance associated
@@ -487,16 +491,13 @@ class EphyviewerConfigurator():
                 spike_train_view.params_controller.on_automatic_color()
 
             # set explicitly assigned spike train colors
-            if self.metadata['amplitude_discriminators'] is not None:
-                for d in self.metadata['amplitude_discriminators']:
-                    if 'color' in d:
-                        try:
-                            index = [st.name for st in seg.spiketrains].index(d['name'])
-                            spike_train_view.by_channel_params['ch{}'.format(index), 'color'] = d['color']
-                        except ValueError:
-                            # the amplitude discriminator name may not have
-                            # been found in the spike train list
-                            pass
+            for name, color in unit_colors.items():
+                try:
+                    index = [st.name for st in seg.spiketrains].index(name)
+                    spike_train_view.by_channel_params['ch{}'.format(index), 'color'] = color
+                except ValueError:
+                    # unit name may not have been found in the spike train list
+                    pass
 
         ########################################################################
         # EPOCHS

--- a/neurotic/gui/config.py
+++ b/neurotic/gui/config.py
@@ -275,6 +275,8 @@ class EphyviewerConfigurator():
         ########################################################################
         # COLORS
 
+        # colors for units given explicitly in amplitude_discriminators, used
+        # for scatter markers, spike trains, and burst epochs
         unit_colors = {}
         if self.metadata['amplitude_discriminators'] is not None:
             unit_colors = {d['name']: d['color'] for d in self.metadata['amplitude_discriminators'] if 'color' in d}
@@ -354,8 +356,8 @@ class EphyviewerConfigurator():
                 # instead of passing colors into AnalogSignalSourceWithScatter
                 # constructor with scatter_colors, first let the constructor
                 # choose reasonable default colors (done above), and only then
-                # override colors for spike trains that have been explicitly
-                # set in amplitude_discriminators (done here)
+                # override colors for units that have been explicitly set in
+                # amplitude_discriminators (done here)
                 sources['signal'][-1].scatter_colors.update(unit_colors)
 
             # useOpenGL=True eliminates the extremely poor performance associated
@@ -490,7 +492,7 @@ class EphyviewerConfigurator():
                 spike_train_view.params_controller.combo_cmap.setCurrentText(self.themes[theme]['cmap'])
                 spike_train_view.params_controller.on_automatic_color()
 
-            # set explicitly assigned spike train colors
+            # set explicitly assigned unit colors
             for name, color in unit_colors.items():
                 try:
                     index = [st.name for st in seg.spiketrains].index(name)
@@ -514,6 +516,15 @@ class EphyviewerConfigurator():
                 epoch_view.params['label_fill_color'] = self.themes[theme]['label_fill_color']
                 epoch_view.params_controller.combo_cmap.setCurrentText(self.themes[theme]['cmap'])
                 epoch_view.params_controller.on_automatic_color()
+
+            # set explicitly assigned unit colors
+            for name, color in unit_colors.items():
+                try:
+                    index = [ep['name'] for ep in sources['epoch'][0].all].index(name + ' burst')
+                    epoch_view.by_channel_params['ch{}'.format(index), 'color'] = color
+                except ValueError:
+                    # unit burst name may not have been found in the epoch list
+                    pass
 
         ########################################################################
         # EPOCH ENCODER

--- a/neurotic/gui/config.py
+++ b/neurotic/gui/config.py
@@ -275,6 +275,12 @@ class EphyviewerConfigurator():
         ########################################################################
         # COLORS
 
+        # colors for signals given explicitly in plots, used for raw signals
+        # and RAUC
+        sig_colors = {}
+        if self.metadata['plots'] is not None:
+            sig_colors = {p['channel']: p['color'] for p in self.metadata['plots'] if 'color' in p}
+
         # colors for units given explicitly in amplitude_discriminators, used
         # for scatter markers, spike trains, and burst epochs
         unit_colors = {}
@@ -388,6 +394,15 @@ class EphyviewerConfigurator():
                 trace_view.params_controller.combo_cmap.setCurrentText(self.themes[theme]['cmap'])
                 trace_view.params_controller.on_automatic_color()
 
+            # set explicitly assigned signal colors
+            for name, color in sig_colors.items():
+                try:
+                    index = [p['channel'] for p in self.metadata['plots']].index(name)
+                    trace_view.by_channel_params['ch{}'.format(index), 'color'] = color
+                except ValueError:
+                    # sig name may not have been found in the trace list
+                    pass
+
             # adjust plot range, scaling, and positioning
             trace_view.params['ylim_max'] = 0.5
             trace_view.params['ylim_min'] = -trace_view.source.nb_channel + 0.5
@@ -433,6 +448,15 @@ class EphyviewerConfigurator():
                 trace_rauc_view.params['label_fill_color'] = self.themes[theme]['label_fill_color']
                 trace_rauc_view.params_controller.combo_cmap.setCurrentText(self.themes[theme]['cmap'])
                 trace_rauc_view.params_controller.on_automatic_color()
+
+            # set explicitly assigned signal colors
+            for name, color in sig_colors.items():
+                try:
+                    index = [p['channel'] for p in self.metadata['plots']].index(name)
+                    trace_rauc_view.by_channel_params['ch{}'.format(index), 'color'] = color
+                except ValueError:
+                    # sig name may not have been found in the rauc trace list
+                    pass
 
             # adjust plot range
             trace_rauc_view.params['ylim_max'] = 0.5


### PR DESCRIPTION
Apply ``amplitude_discriminators`` colors to detected burst epochs (was already applied to scatter points and spike trains).

Add color option for signal plots, which is applied to signals in both raw TraceViewer and RAUC TraceViewer.