### PR TITLE
Add CLI and GUI options for enabling debug log messages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,7 +164,8 @@ The command line interface accepts other arguments too:
 
 .. code-block::
 
-    usage: neurotic [-h] [-V] [--no-lazy] [--thick-traces] [--show-datetime]
+    usage: neurotic [-h] [-V] [--debug] [--no-lazy] [--thick-traces]
+                    [--show-datetime]
                     [--theme {light,dark,original,printer-friendly}]
                     [--launch-example-notebook]
                     [file] [dataset]
@@ -182,6 +183,7 @@ The command line interface accepts other arguments too:
     optional arguments:
       -h, --help            show this help message and exit
       -V, --version         show program's version number and exit
+      --debug               enable detailed log messages for debugging
       --no-lazy             do not use fast loading (default: use fast loading)
       --thick-traces        enable support for traces with thick lines, which has
                             a performance cost (default: disable thick line

--- a/neurotic/gui/standalone.py
+++ b/neurotic/gui/standalone.py
@@ -15,7 +15,7 @@ import pkg_resources
 import quantities as pq
 from ephyviewer import QT, QT_MODE
 
-from .. import __version__, log_file
+from .. import __version__, default_log_level, log_file
 from ..datasets import MetadataSelector, load_dataset
 from ..datasets.metadata import _selector_labels
 from ..elephant_tools import _rauc
@@ -197,6 +197,12 @@ class MainWindow(QT.QMainWindow):
 
         self.help_menu = self.menuBar().addMenu(self.tr('&Help'))
 
+        self.do_toggle_debug_logging = QT.QAction('Show and log &debug messages', self)
+        self.do_toggle_debug_logging.setCheckable(True)
+        self.do_toggle_debug_logging.setChecked(logger.parent.level == logging.DEBUG)
+        self.do_toggle_debug_logging.triggered.connect(self.toggle_debug_logging)
+        self.help_menu.addAction(self.do_toggle_debug_logging)
+
         do_view_log_file = QT.QAction('View &log file', self)
         do_view_log_file.triggered.connect(self.view_log_file)
         self.help_menu.addAction(do_view_log_file)
@@ -299,6 +305,17 @@ class MainWindow(QT.QMainWindow):
         except Exception:
 
             logger.exception('Encountered a fatal error. Traceback will be written to log file.')
+
+    def toggle_debug_logging(self, checked):
+        """
+        Toggle log filtering level between its original level and debug mode
+        """
+        if checked:
+            logger.parent.setLevel(logging.DEBUG)
+            logger.debug('Debug messages enabled')
+        else:
+            logger.debug('Disabling debug messages')
+            logger.parent.setLevel(default_log_level)
 
     def view_log_file(self):
         """

--- a/neurotic/scripts.py
+++ b/neurotic/scripts.py
@@ -38,6 +38,8 @@ def parse_args(argv):
 
     parser.add_argument('-V', '--version', action='version',
                         version='neurotic {}'.format(__version__))
+    parser.add_argument('--debug', action='store_true', dest='debug',
+                        help='enable detailed log messages for debugging')
     parser.add_argument('--no-lazy', action='store_false', dest='lazy',
                         help='do not use fast loading (default: use fast ' \
                              'loading)')
@@ -60,6 +62,13 @@ def parse_args(argv):
                              'args will be ignored)')
 
     args = parser.parse_args(argv[1:])
+
+    if args.debug:
+        logger.parent.setLevel(logging.DEBUG)
+        if not args.launch_example_notebook:
+            # show only if Jupyter won't be launched, since the setting will
+            # not carry over into the kernel started by Jupyter
+            logger.debug('Debug messages enabled')
 
     return args
 

--- a/neurotic/tests/test_cli.py
+++ b/neurotic/tests/test_cli.py
@@ -68,6 +68,8 @@ class CLITestCase(unittest.TestCase):
         args = neurotic.parse_args(argv)
         app = mkQApp()
         win = neurotic.win_from_args(args)
+        self.assertFalse(win.do_toggle_debug_logging.isChecked(),
+                         'debug logging enabled without --debug')
         self.assertTrue(win.lazy, 'lazy loading disabled without --no-lazy')
         self.assertFalse(win.support_increased_line_width,
                          'thick traces enabled without --thick-traces')
@@ -79,6 +81,15 @@ class CLITestCase(unittest.TestCase):
         self.assertEqual(win.metadata_selector._selection,
                          self.default_dataset,
                          'dataset was not set to default dataset')
+
+    def test_debug(self):
+        """Test that --debug enables logging of debug messages"""
+        argv = ['neurotic', '--debug']
+        args = neurotic.parse_args(argv)
+        app = mkQApp()
+        win = neurotic.win_from_args(args)
+        self.assertTrue(win.do_toggle_debug_logging.isChecked(),
+                        'debug logging disabled with --debug')
 
     def test_no_lazy(self):
         """Test that --no-lazy disables lazy loading"""


### PR DESCRIPTION
The new ``--debug`` option for the command line interface and the corresponding "Show and log debug messages" option for the graphical user interface enable more detailed log messages.

This includes adding file, function, and line numbers to existing messages when they are written to the log file, as well as decreasing the log level to allow for debug messages to be recorded. (No interesting debug messages exist yet!)