### PR TITLE
Raise the default threshold for PyAV messages from warning to critical

### DIFF
--- a/neurotic/gui/config.py
+++ b/neurotic/gui/config.py
@@ -23,6 +23,11 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+# raise the threshold for PyAV messages printed to the console from
+# warning to critical
+logging.getLogger('libav').setLevel(logging.CRITICAL)
+
+
 pq.mN = pq.UnitQuantity('millinewton', pq.N/1e3, symbol = 'mN');  # define millinewton
 
 

--- a/neurotic/gui/standalone.py
+++ b/neurotic/gui/standalone.py
@@ -313,9 +313,18 @@ class MainWindow(QT.QMainWindow):
         if checked:
             logger.parent.setLevel(logging.DEBUG)
             logger.debug('Debug messages enabled')
+
+            # lower the threshold for PyAV messages printed to the console from
+            # critical to warning
+            logging.getLogger('libav').setLevel(logging.WARNING)
+
         else:
             logger.debug('Disabling debug messages')
             logger.parent.setLevel(default_log_level)
+
+            # raise the threshold for PyAV messages printed to the console from
+            # warning to critical
+            logging.getLogger('libav').setLevel(logging.CRITICAL)
 
     def view_log_file(self):
         """

--- a/neurotic/scripts.py
+++ b/neurotic/scripts.py
@@ -65,6 +65,11 @@ def parse_args(argv):
 
     if args.debug:
         logger.parent.setLevel(logging.DEBUG)
+
+        # lower the threshold for PyAV messages printed to the console from
+        # critical to warning
+        logging.getLogger('libav').setLevel(logging.WARNING)
+
         if not args.launch_example_notebook:
             # show only if Jupyter won't be launched, since the setting will
             # not carry over into the kernel started by Jupyter


### PR DESCRIPTION
For some video files (which may contain non-fatal problems), PyAV can be extremely verbose, generating many warnings in the console. This change raises the threshold for PyAV logging, so that only critical messages are printed to the console. The PyAV logging threshold remains at its default, lower level (warning) if neurotic's debug mode is enabled.