### PR TITLE
Add shell commands to example Jupyter notebook for installing neurotic

### DIFF
--- a/neurotic/example/example-notebook.ipynb
+++ b/neurotic/example/example-notebook.ipynb
@@ -21,6 +21,36 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Install Packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# check whether neurotic is currently installed\n",
+    "!pip show neurotic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# install the latest release version\n",
+    "# !pip install -U neurotic\n",
+    "\n",
+    "# alternatively, install the latest development version\n",
+    "# !pip install -U git+https://github.com/jpgill86/neurotic.git"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Import Packages"
    ]
   },


### PR DESCRIPTION
Useful when the notebook is launched on a cloud server like Google Colab or Binder where the package may not already be installed.