### PR TITLE
RAUC disabled by default

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -695,8 +695,9 @@ provided there.
 The choice of baseline is controlled by the ``rauc_baseline`` metadata
 parameter, which may have the value ``None`` (default), ``'mean'``, or
 ``'median'``. The size of the bins determines how smooth the RAUC time series
-is and is set by ``rauc_bin_duration``, given in seconds. The default bin
-duration is 0.1 seconds.
+is and is set by ``rauc_bin_duration``, given in seconds. If
+``rauc_bin_duration`` is not specified (default ``None``), RAUC time series
+will not be calculated.
 
 .. _config-metadata-example:
 

--- a/neurotic/datasets/data.py
+++ b/neurotic/datasets/data.py
@@ -101,18 +101,18 @@ def load_dataset(metadata, lazy=False, signal_group_mode='split-all', filter_eve
 
     # compute rectified area under the curve (RAUC) for each signal if not
     # using lazy loading of signals
-    if not lazy:
+    if not lazy and metadata.get('rauc_bin_duration', None) is not None:
         for sig in blk.segments[0].analogsignals:
             rauc_sig = _elephant_tools.rauc(
                 signal=sig,
                 baseline=metadata.get('rauc_baseline', None),
-                bin_duration=metadata.get('rauc_bin_duration', 0.1)*pq.s,
+                bin_duration=metadata['rauc_bin_duration']*pq.s,
             )
             rauc_sig.name = sig.name + ' RAUC'
             sig.annotate(
                 rauc_sig=rauc_sig,
                 rauc_baseline=metadata.get('rauc_baseline', None),
-                rauc_bin_duration=metadata.get('rauc_bin_duration', 0.1)*pq.s,
+                rauc_bin_duration=metadata['rauc_bin_duration']*pq.s,
             )
 
     return blk

--- a/neurotic/datasets/metadata.py
+++ b/neurotic/datasets/metadata.py
@@ -412,7 +412,7 @@ def _defaults_for_key(key):
 
         # width of bins in seconds used for calculating rectified area under
         # the curve (RAUC) for signals
-        'rauc_bin_duration': 0.1,
+        'rauc_bin_duration': None,
     }
 
     return defaults

--- a/neurotic/example/metadata.yml
+++ b/neurotic/example/metadata.yml
@@ -89,3 +89,5 @@ example dataset:
 
         - spiketrain: B4/B5
           thresholds: [3, 3] # Hz
+
+    rauc_bin_duration: 0.1 # seconds, used only if fast loading is off (lazy=False)


### PR DESCRIPTION
Previously, RAUCs were always calculated if ``lazy=False``, i.e., there was no way to disable them if other non-lazy features were needed. Now, RAUCs are not calculated if the bin duration is set to None, which is the new default. So now to calculate RAUCs, ``rauc_bin_duration`` must be given explicitly (as well as ``lazy=False``).