### PR TITLE
Allow data_file to be unspecified in metadata and AnalogSignals to be optional

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -57,8 +57,7 @@ used.
 
 Paths to individual files within the dataset are provided using keys listed
 below. These paths should be given relative to ``data_dir``. If ``data_dir`` is
-flat (no subdirectories), these should be simply the file names. Only
-``data_file`` is required.
+flat (no subdirectories), these should be simply the file names.
 
 ======================  ========================================================
 Key                     Description

--- a/neurotic/datasets/data.py
+++ b/neurotic/datasets/data.py
@@ -189,6 +189,10 @@ def _read_data_file(metadata, lazy=False, signal_group_mode='split-all'):
         # some IOs do not have signal_group_mode
         blk = io.read_block(lazy=lazy)
 
+    if lazy and isinstance(io, neo.rawio.baserawio.BaseRawIO):
+        # store the rawio for use with AnalogSignalFromNeoRawIOSource
+        blk.rawio = io
+
     # load all objects except analog signals
     if lazy:
 

--- a/neurotic/datasets/metadata.py
+++ b/neurotic/datasets/metadata.py
@@ -338,7 +338,7 @@ def _defaults_for_key(key):
         'epoch_encoder_file': None,
 
         # list of labels for epoch encoder
-        'epoch_encoder_possible_labels': ['Type 1', 'Type 2', 'Type 3'],
+        'epoch_encoder_possible_labels': [],
 
         # list of dicts giving name, channel, units, amplitude window, epoch window, color for each unit
         # - e.g. [{'name': 'Unit X', 'channel': 'Channel A', 'units': 'uV', 'amplitude': [75, 150], 'epoch': 'Type 1', 'color': 'ff0000'}, ...]

--- a/neurotic/gui/config.py
+++ b/neurotic/gui/config.py
@@ -631,7 +631,7 @@ class EphyviewerConfigurator():
 
         if self.is_shown('epoch_encoder') and self.metadata.get('epoch_encoder_file', None) is not None:
 
-            possible_labels = self.metadata['epoch_encoder_possible_labels']
+            possible_labels = self.metadata.get('epoch_encoder_possible_labels', [])
 
             # append labels found in the epoch encoder file but not in the
             # epoch_encoder_possible_labels list, preserving the original
@@ -641,9 +641,17 @@ class EphyviewerConfigurator():
                 if label not in possible_labels:
                     possible_labels.append(label)
 
-            writable_epoch_source = NeuroticWritableEpochSource(
-                filename = _abs_path(self.metadata, 'epoch_encoder_file'),
-                possible_labels = possible_labels,
+            if not possible_labels:
+
+                # an empty epoch encoder file and an empty list of possible
+                # labels were provided
+                logger.warning('Ignoring epoch_encoder_file because epoch_encoder_possible_labels was unspecified')
+
+            else:
+
+                writable_epoch_source = NeuroticWritableEpochSource(
+                    filename = _abs_path(self.metadata, 'epoch_encoder_file'),
+                    possible_labels = possible_labels,
             )
 
             epoch_encoder = ephyviewer.EpochEncoder(source = writable_epoch_source, name = 'epoch encoder')

--- a/neurotic/gui/config.py
+++ b/neurotic/gui/config.py
@@ -100,6 +100,10 @@ class EphyviewerConfigurator():
         }
 
         # hide and disable viewers for which inputs are missing
+        if not self.blk.segments[0].analogsignals:
+            self.viewer_settings['traces']['show'] = False
+            self.viewer_settings['traces']['disabled'] = True
+            self.viewer_settings['traces']['reason'] = 'Cannot enable because there are no signals'
         if not [sig.annotations['rauc_sig'] for sig in blk.segments[0].analogsignals if 'rauc_sig' in sig.annotations]:
             self.viewer_settings['traces_rauc']['show'] = False
             self.viewer_settings['traces_rauc']['disabled'] = True
@@ -652,18 +656,18 @@ class EphyviewerConfigurator():
                 writable_epoch_source = NeuroticWritableEpochSource(
                     filename = _abs_path(self.metadata, 'epoch_encoder_file'),
                     possible_labels = possible_labels,
-            )
+                )
 
-            epoch_encoder = ephyviewer.EpochEncoder(source = writable_epoch_source, name = 'epoch encoder')
-            epoch_encoder.params['exclusive_mode'] = False
-            win.add_view(epoch_encoder)
+                epoch_encoder = ephyviewer.EpochEncoder(source = writable_epoch_source, name = 'epoch encoder')
+                epoch_encoder.params['exclusive_mode'] = False
+                win.add_view(epoch_encoder)
 
-            # set the theme
-            if theme != 'original':
-                epoch_encoder.params['background_color'] = self.themes[theme]['background_color']
-                epoch_encoder.params['vline_color'] = self.themes[theme]['vline_color']
-                epoch_encoder.params['label_fill_color'] = self.themes[theme]['label_fill_color']
-                # TODO add support for combo_cmap
+                # set the theme
+                if theme != 'original':
+                    epoch_encoder.params['background_color'] = self.themes[theme]['background_color']
+                    epoch_encoder.params['vline_color'] = self.themes[theme]['vline_color']
+                    epoch_encoder.params['label_fill_color'] = self.themes[theme]['label_fill_color']
+                    # TODO add support for combo_cmap
 
         ########################################################################
         # VIDEO


### PR DESCRIPTION
If ``data_file`` is omitted from the metadata, an empty Neo Block is created. This is, as usual, subsequently populated with data from other files, like epochs from ``annotations_file``.

Consequently, these changes also allow neurotic to run when there are no AnalogSignals.