### PR TITLE
Add options for scaling the user interface

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,7 +208,7 @@ The command line interface accepts other arguments too:
 .. code-block::
 
     usage: neurotic [-h] [-V] [--debug] [--no-lazy] [--thick-traces]
-                    [--show-datetime]
+                    [--show-datetime] [--ui-scale {tiny,small,large,huge}]
                     [--theme {light,dark,original,printer-friendly}]
                     [--launch-example-notebook]
                     [file] [dataset]
@@ -234,6 +234,9 @@ The command line interface accepts other arguments too:
       --show-datetime       display the real-world date and time, which may be
                             inaccurate depending on file type and acquisition
                             software (default: do not display)
+      --ui-scale {tiny,small,large,huge}
+                            the scale of user interface elements, such as text
+                            (default: small)
       --theme {light,dark,original,printer-friendly}
                             a color theme for the GUI (default: light)
       --launch-example-notebook

--- a/neurotic/gui/config.py
+++ b/neurotic/gui/config.py
@@ -99,6 +99,28 @@ class EphyviewerConfigurator():
             'label_fill_color': '#DDDDDDDD', # transparent light gray
         }
 
+        self.ui_scales = {}
+        self.ui_scales['tiny'] = {
+            'app_font_size': 6,
+            'channel_label_size': 6,
+            'scatter_size': 3,
+        }
+        self.ui_scales['small'] = {
+            'app_font_size': 8,
+            'channel_label_size': 8,
+            'scatter_size': 5,
+        }
+        self.ui_scales['large'] = {
+            'app_font_size': 12,
+            'channel_label_size': 14,
+            'scatter_size': 10,
+        }
+        self.ui_scales['huge'] = {
+            'app_font_size': 14,
+            'channel_label_size': 16,
+            'scatter_size': 15,
+        }
+
         # hide and disable viewers for which inputs are missing
         if not self.blk.segments[0].analogsignals:
             self.viewer_settings['traces']['show'] = False
@@ -227,17 +249,17 @@ class EphyviewerConfigurator():
         for name in self.viewer_settings:
             self.hide(name)
 
-    def launch_ephyviewer(self, theme='light', support_increased_line_width=False, show_datetime=False, datetime_format='%Y-%m-%d %H:%M:%S'):
+    def launch_ephyviewer(self, theme='light', ui_scale='small', support_increased_line_width=False, show_datetime=False, datetime_format='%Y-%m-%d %H:%M:%S'):
         """
         Start a Qt app and create an ephyviewer window.
         """
 
         app = ephyviewer.mkQApp()
-        win = self.create_ephyviewer_window(theme=theme, support_increased_line_width=support_increased_line_width, show_datetime=show_datetime, datetime_format=datetime_format)
+        win = self.create_ephyviewer_window(theme=theme, ui_scale=ui_scale, support_increased_line_width=support_increased_line_width, show_datetime=show_datetime, datetime_format=datetime_format)
         win.show()
         app.exec_()
 
-    def create_ephyviewer_window(self, theme='light', support_increased_line_width=False, show_datetime=False, datetime_format='%Y-%m-%d %H:%M:%S'):
+    def create_ephyviewer_window(self, theme='light', ui_scale='small', support_increased_line_width=False, show_datetime=False, datetime_format='%Y-%m-%d %H:%M:%S'):
         """
         Load data into each ephyviewer viewer and return the main window.
         """
@@ -284,6 +306,9 @@ class EphyviewerConfigurator():
 
         # delete on close so that memory and file resources are released
         win.setAttribute(ephyviewer.QT.WA_DeleteOnClose, True)
+
+        # set the font size for most text
+        win.setStyleSheet(f"font: {self.ui_scales[ui_scale]['app_font_size']}pt")
 
         ########################################################################
         # COLORS
@@ -402,8 +427,9 @@ class EphyviewerConfigurator():
 
             trace_view.params['xratio'] = self.metadata.get('past_fraction', 0.3)
             trace_view.params['auto_scale_factor'] = 0.02
-            trace_view.params['scatter_size'] = 5
+            trace_view.params['scatter_size'] = self.ui_scales[ui_scale]['scatter_size']
             trace_view.params['line_width'] = line_width
+            trace_view.params['label_size'] = self.ui_scales[ui_scale]['channel_label_size']
             trace_view.params['display_labels'] = True
             trace_view.params['antialias'] = True
 
@@ -463,6 +489,7 @@ class EphyviewerConfigurator():
 
                 trace_rauc_view.params['xratio'] = self.metadata.get('past_fraction', 0.3)
                 trace_rauc_view.params['line_width'] = line_width
+                trace_rauc_view.params['label_size'] = self.ui_scales[ui_scale]['channel_label_size']
                 trace_rauc_view.params['display_labels'] = True
                 trace_rauc_view.params['display_offset'] = True
                 trace_rauc_view.params['antialias'] = True
@@ -553,6 +580,7 @@ class EphyviewerConfigurator():
                     pass
 
             spike_train_view.params['xratio'] = self.metadata.get('past_fraction', 0.3)
+            spike_train_view.params['label_size'] = self.ui_scales[ui_scale]['channel_label_size']
 
         ########################################################################
         # TRACES OF FIRING RATES
@@ -580,6 +608,7 @@ class EphyviewerConfigurator():
 
                 trace_rates_view.params['xratio'] = self.metadata.get('past_fraction', 0.3)
                 trace_rates_view.params['line_width'] = line_width
+                trace_rates_view.params['label_size'] = self.ui_scales[ui_scale]['channel_label_size']
                 trace_rates_view.params['display_labels'] = True
                 trace_rates_view.params['display_offset'] = True
                 trace_rates_view.params['antialias'] = True
@@ -637,6 +666,7 @@ class EphyviewerConfigurator():
                     pass
 
             epoch_view.params['xratio'] = self.metadata.get('past_fraction', 0.3)
+            epoch_view.params['label_size'] = self.ui_scales[ui_scale]['channel_label_size']
 
         ########################################################################
         # EPOCH ENCODER
@@ -678,6 +708,7 @@ class EphyviewerConfigurator():
                     # TODO add support for combo_cmap
 
                 epoch_encoder.params['xratio'] = self.metadata.get('past_fraction', 0.3)
+                epoch_encoder.params['label_size'] = self.ui_scales[ui_scale]['channel_label_size']
 
         ########################################################################
         # VIDEO

--- a/neurotic/gui/standalone.py
+++ b/neurotic/gui/standalone.py
@@ -64,7 +64,7 @@ class MainWindow(QT.QMainWindow):
 
     request_download = QT.pyqtSignal()
 
-    def __init__(self, file=None, initial_selection=None, lazy=True, theme='light', support_increased_line_width=False, show_datetime=False):
+    def __init__(self, file=None, initial_selection=None, lazy=True, theme='light', ui_scale='small', support_increased_line_width=False, show_datetime=False):
         """
         Initialize a new MainWindow.
         """
@@ -82,6 +82,9 @@ class MainWindow(QT.QMainWindow):
 
         # available themes are 'light', 'dark', and 'original'
         self.theme = theme
+
+        # available sizes are 'tiny', 'small', 'large', and 'huge'
+        self.ui_scale = ui_scale
 
         # support_increased_line_width=True eliminates the extremely poor
         # performance associated with TraceViewer's line_width > 1.0, but it
@@ -186,6 +189,20 @@ class MainWindow(QT.QMainWindow):
         do_toggle_show_datetime.triggered.connect(self.toggle_show_datetime)
 
         appearance_menu = self.menuBar().addMenu(self.tr('&Appearance'))
+
+        ui_scale_group = QT.QActionGroup(appearance_menu)
+        ui_scale_actions = {}
+        for size in ['tiny', 'small', 'large', 'huge']:
+            ui_scale_actions[size] = appearance_menu.addAction(f'&{size.capitalize()} scale')
+            ui_scale_actions[size].setCheckable(True)
+            ui_scale_actions[size].triggered.connect(lambda checked, size=size: self.set_ui_scale(size))
+            ui_scale_group.addAction(ui_scale_actions[size])
+        if self.ui_scale in ui_scale_actions:
+            ui_scale_actions[self.ui_scale].setChecked(True)
+        else:
+            raise ValueError('ui scale "{}" is unrecognized'.format(self.ui_scale))
+
+        appearance_menu.addSeparator()
 
         theme_group = QT.QActionGroup(appearance_menu)
         theme_actions = {}
@@ -316,7 +333,7 @@ class MainWindow(QT.QMainWindow):
             ephyviewer_config = EphyviewerConfigurator(metadata, blk, self.lazy)
             ephyviewer_config.show_all()
 
-            win = ephyviewer_config.create_ephyviewer_window(theme=self.theme, support_increased_line_width=self.support_increased_line_width, show_datetime=self.show_datetime)
+            win = ephyviewer_config.create_ephyviewer_window(theme=self.theme, ui_scale=self.ui_scale, support_increased_line_width=self.support_increased_line_width, show_datetime=self.show_datetime)
             self.windows.append(win)
             win.destroyed.connect(lambda qobject, i=len(self.windows)-1: self.free_resources(i))
             win.show()
@@ -474,6 +491,9 @@ class MainWindow(QT.QMainWindow):
 
     def toggle_show_datetime(self, checked):
         self.show_datetime = checked
+
+    def set_ui_scale(self, size):
+        self.ui_scale = size
 
     def set_theme(self, theme):
         self.theme = theme

--- a/neurotic/scripts.py
+++ b/neurotic/scripts.py
@@ -60,6 +60,11 @@ def parse_args(argv):
                         help='display the real-world date and time, which ' \
                              'may be inaccurate depending on file type and ' \
                              'acquisition software (default: do not display)')
+    parser.add_argument('--ui-scale', dest='ui_scale',
+                        choices=['tiny', 'small', 'large', 'huge'],
+                        default='small', help='the scale of user interface ' \
+                                              'elements, such as text ' \
+                                              '(default: small)')
     parser.add_argument('--theme', choices=['light', 'dark', 'original',
                                             'printer-friendly'],
                         default='light', help='a color theme for the GUI ' \
@@ -92,7 +97,7 @@ def win_from_args(args):
     """
 
     win = MainWindow(file=args.file, initial_selection=args.dataset,
-                     lazy=args.lazy, theme=args.theme,
+                     lazy=args.lazy, theme=args.theme, ui_scale=args.ui_scale,
                      support_increased_line_width=args.thick,
                      show_datetime=args.datetime)
     return win

--- a/neurotic/tests/test_cli.py
+++ b/neurotic/tests/test_cli.py
@@ -75,6 +75,8 @@ class CLITestCase(unittest.TestCase):
                          'thick traces enabled without --thick-traces')
         self.assertFalse(win.show_datetime,
                          'datetime enabled without --show-datetime')
+        self.assertEqual(win.ui_scale, 'small',
+                         'ui_scale changed without --ui-scale')
         self.assertEqual(win.theme, 'light', 'theme changed without --theme')
         self.assertEqual(win.metadata_selector.file, self.default_file,
                          'file was not set to default')
@@ -116,6 +118,30 @@ class CLITestCase(unittest.TestCase):
         win = neurotic.win_from_args(args)
         self.assertTrue(win.show_datetime,
                         'datetime not displayed with --show-datetime')
+
+    def test_ui_scale(self):
+        """Test that --ui-scale changes the ui_scale"""
+        app = mkQApp()
+
+        argv = ['neurotic', '--ui-scale', 'tiny']
+        args = neurotic.parse_args(argv)
+        win = neurotic.win_from_args(args)
+        self.assertEqual(win.ui_scale, 'tiny', 'unexpected scale')
+
+        argv = ['neurotic', '--ui-scale', 'small']
+        args = neurotic.parse_args(argv)
+        win = neurotic.win_from_args(args)
+        self.assertEqual(win.ui_scale, 'small', 'unexpected scale')
+
+        argv = ['neurotic', '--ui-scale', 'large']
+        args = neurotic.parse_args(argv)
+        win = neurotic.win_from_args(args)
+        self.assertEqual(win.ui_scale, 'large', 'unexpected scale')
+
+        argv = ['neurotic', '--ui-scale', 'huge']
+        args = neurotic.parse_args(argv)
+        win = neurotic.win_from_args(args)
+        self.assertEqual(win.ui_scale, 'huge', 'unexpected scale')
 
     def test_theme(self):
         """Test that --theme changes the theme"""


### PR DESCRIPTION
The new parameter controls widget text size, channel label size, and scatter size for plotted signal peaks.

UI scale can be adjusted in the standalone app via the "Appearance" menu, using the command line interface argument ``--ui-scale``, or by passing the ``ui_scale`` parameter to ``launch_ephyviewer`` or ``create_ephyviewer_window``.

Closes #153.