### PR TITLE
Ignore video_file if PyAV is not installed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,16 +135,16 @@ On Windows, this will also create a Start Menu shortcut for launching the app.
 Alternate Method: pip
 .....................
 
-Installation of **neurotic** via ``pip`` will install nearly all of its
-dependencies automatically, with one exception. **neurotic** requires PyAV_,
-which is not easily installed with ``pip`` on some systems, especially Windows.
-The easiest way to install PyAV is using conda_::
-
-    conda install -c conda-forge av
-
 Install **neurotic** from PyPI_ using ::
 
     pip install neurotic
+
+Note that installation via ``pip`` skips one dependency: PyAV_, which is
+required for displaying videos, and without which **neurotic** will ignore
+videos. PyAV is not easily installed with ``pip`` on some systems, especially
+Windows. The easiest way to separately install PyAV is using conda_::
+
+    conda install -c conda-forge av
 
 Updating neurotic
 -----------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -51,16 +51,16 @@ On Windows, this will also create a Start Menu shortcut for launching the app.
 Alternate Method: pip
 ---------------------
 
-Installation of **neurotic** via ``pip`` will install nearly all of its
-dependencies automatically, with one exception. **neurotic** requires PyAV_,
-which is not easily installed with ``pip`` on some systems, especially Windows.
-The easiest way to install PyAV is using conda_::
-
-    conda install -c conda-forge av
-
 Install **neurotic** from PyPI_ using ::
 
     pip install neurotic
+
+Note that installation via ``pip`` skips one dependency: PyAV_, which is
+required for displaying videos, and without which **neurotic** will ignore
+videos. PyAV is not easily installed with ``pip`` on some systems, especially
+Windows. The easiest way to separately install PyAV is using conda_::
+
+    conda install -c conda-forge av
 
 
 .. _conda:              https://docs.conda.io/projects/conda/en/latest/user-guide/install/

--- a/neurotic/gui/config.py
+++ b/neurotic/gui/config.py
@@ -153,10 +153,16 @@ class EphyviewerConfigurator():
             self.viewer_settings['epoch_encoder']['show'] = False
             self.viewer_settings['epoch_encoder']['disabled'] = True
             self.viewer_settings['epoch_encoder']['reason'] = 'Cannot enable because epoch_encoder_file is not set'
+        if not ephyviewer.HAVE_AV:
+            self.viewer_settings['video']['show'] = False
+            self.viewer_settings['video']['disabled'] = True
+            self.viewer_settings['video']['reason'] = 'Cannot enable because PyAV is not installed'
         if not self.metadata.get('video_file', None):
             self.viewer_settings['video']['show'] = False
             self.viewer_settings['video']['disabled'] = True
             self.viewer_settings['video']['reason'] = 'Cannot enable because video_file is not set'
+        if not ephyviewer.HAVE_AV and self.metadata.get('video_file', None):
+            logger.warning('Ignoring video_file because PyAV is not installed')
 
         # warn about potential video sync problems
         if metadata.get('video_file', None) is not None and metadata.get('video_offset', None) is None:


### PR DESCRIPTION
This change improves the viability of installing via ``pip`` (instead of ``conda``), which does not provide PyAV.

Closes #200