### PR TITLE
Add neurotic_version to metadata

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -197,13 +197,16 @@ Global Configuration Settings
 -----------------------------
 
 The top-level name ``neurotic_config`` is reserved for configuration settings
-that apply to all datasets or to the app itself. Presently, only one
-configuration setting is implemented, but future versions of **neurotic** may
-add more under this name.
+that apply to all datasets or to the app itself. The following settings may be
+nested beneath ``neurotic_config``.
 
 ======================  ========================================================
 Key                     Description
 ======================  ========================================================
+``neurotic_version``    A `version specification`_ stating the version of
+                        **neurotic** required by the metadata. Presently, if
+                        the requirement is not met, only a warning is issued.
+                        Quotation marks around the spec are usually required.
 ``remote_data_root``    A URL prepended to each ``remote_data_dir`` that is not
                         already a full URL (i.e., does not already begin with a
                         protocol scheme like ``https://``)
@@ -214,6 +217,7 @@ For example:
 .. code-block:: yaml
 
     neurotic_config:
+        neurotic_version:   '>=1.4,<2'
         remote_data_root:   http://myserver
 
     my favorite dataset:
@@ -725,7 +729,8 @@ without arguments:
    :language: yaml
 
 
-.. _elephant:             https://elephant.readthedocs.io/en/latest
-.. _GIN:                  https://gin.g-node.org
-.. _Neo:                  https://github.com/NeuralEnsemble/python-neo
-.. _tridesclous:          https://github.com/tridesclous/tridesclous
+.. _elephant:               https://elephant.readthedocs.io/en/latest
+.. _GIN:                    https://gin.g-node.org
+.. _Neo:                    https://github.com/NeuralEnsemble/python-neo
+.. _tridesclous:            https://github.com/tridesclous/tridesclous
+.. _version specification:  https://www.python.org/dev/peps/pep-0440/#version-specifiers

--- a/neurotic/datasets/metadata.py
+++ b/neurotic/datasets/metadata.py
@@ -10,7 +10,10 @@ metadata files.
 import os
 import urllib
 import yaml
+from packaging.specifiers import SpecifierSet
+from packaging import version
 
+from .. import __version__
 from ..datasets.download import download
 
 import logging
@@ -244,10 +247,21 @@ def _load_metadata(file = 'metadata.yml', local_data_root = None, remote_data_ro
     config = md.pop('neurotic_config', None)
     if isinstance(config, dict):
         # process global settings
+        neurotic_version = config.get('neurotic_version', None)
         remote_data_root_from_file = config.get('remote_data_root', None)
     else:
         # use defaults for all global settings
+        neurotic_version = None
         remote_data_root_from_file = None
+
+    # check neurotic version requirements
+    if neurotic_version is not None:
+        version_spec = SpecifierSet(str(neurotic_version), prereleases=True)
+        if version.parse(__version__) not in version_spec:
+            logger.warning('the installed version of neurotic '
+                           f'({__version__}) does not meet version '
+                           'requirements specified in the metadata file: '
+                           f'{version_spec}')
 
     # use remote_data_root passed to function preferentially
     if remote_data_root is not None:

--- a/neurotic/example/metadata.yml
+++ b/neurotic/example/metadata.yml
@@ -1,3 +1,6 @@
+neurotic_config:
+    neurotic_version: '>=1.4' # required for firing_rates
+
 example dataset:
     description: This is an example data set
 


### PR DESCRIPTION
The new, optional ``neurotic_version`` setting should be nested under ``neurotic_config``. If the installed version of **neurotic** does not meet the provided specification (e.g. ``">=1.4,<2"``), a warning is issued.

Closes #235.