### PR TITLE
Add amplitude discriminator parameter for extrema type (peak or trough), and epoch annotation for SpikeTrain

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -484,15 +484,23 @@ provides bandpass filtering.
 Amplitude Discriminators
 ------------------------
 
-Spikes with peaks that fall within amplitude windows given by
+Spikes with peaks (or troughs) that fall within amplitude windows given by
 ``amplitude_discriminators`` can be automatically detected by *neurotic* on the
-basis of amplitude alone. Note that amplitude discriminators are only applied
-if fast loading is off (``lazy=False``).
+basis of amplitude. Note that amplitude discriminators are only applied if fast
+loading is off (``lazy=False``).
 
 Detected spikes are indicated on the signals with markers, and spike trains are
 displayed in a raster plot. Optionally, a color may be specified for an
 amplitude discriminator using a single letter color code (e.g., ``'b'`` for
 blue or ``'k'`` for black) or a hexadecimal color code (e.g., ``'1b9e77'``).
+
+The algorithm can detect either peaks or troughs in the signal. When both the
+lower and upper bounds for amplitude windows are positive, the default behavior
+is to detect peaks. When both are negative, the default is to detect troughs.
+These defaults can be overridden using `type: trough` or `type: peak`,
+respectively. This is useful when, for example, detecting subthreshold
+excitatory postsynaptic potentials. If the signs of the bounds differ, explicit
+specification of the type is required.
 
 In addition to restricting spike detection for a given unit to an amplitude
 window, detection can also be limited in time to overlap with epochs with a
@@ -522,17 +530,25 @@ for each amplitude discriminator.
               epoch: Unit 2 activity
               color: 'e6ab02'
 
-Here two units are detected on the same channel with different amplitude
-windows. Any peaks between 50 and 150 microvolts on the "Extracellular" channel
-will be tagged as a spike belonging to "Unit 1". The discriminator for "Unit 2"
-provides the optional ``epoch`` parameter. This restricts detection of "Unit 2"
-to spikes within the amplitude window that occur at the same time as epochs
-labeled "Unit 2 activity". These epochs can be created by the epoch encoder
-(reload required to rerun spike detection at launch-time), specified in the
-read-only ``annotations_file``, or even be contained in the ``data_file`` if
-the format supports epochs.
+            - name: Unit 3
+              channel: Intracellular
+              units: mV
+              amplitude: [-10, 60]
+              type: peak
 
-Amplitude windows are permitted to be negative.
+Here two units are detected on the "Extracellular" channel with different
+amplitude windows, and a third unit is detected on the "Intracellular" channel.
+On the "Extracellular" channel, any peaks between 50 and 150 microvolts will be
+tagged as a spike belonging to "Unit 1". The discriminator for "Unit 2" detects
+smaller peaks, between 20 and 50 microvolts, and it provides the optional
+``epoch`` parameter. This restricts detection of "Unit 2" to spikes within the
+amplitude window that occur at the same time as epochs labeled "Unit 2
+activity". These epochs can be created by the epoch encoder (reload required to
+rerun spike detection at launch-time), specified in the read-only
+``annotations_file``, or even be contained in the ``data_file`` if the format
+supports epochs. Finally, peaks between -10 and +60 millivolts will be detected
+on the "Intracellular" channel; because the signs of these bounds differ, the
+type (peak or trough) must be explicitly given.
 
 .. _config-metadata-tridesclous:
 

--- a/neurotic/datasets/data.py
+++ b/neurotic/datasets/data.py
@@ -518,11 +518,14 @@ def _create_neo_spike_trains_from_dataframe(dataframe, metadata, t_start, t_stop
             st = neo.SpikeTrain(
                 name = str(spike_label),
                 file_origin = _abs_path(metadata, 'tridesclous_file'),
-                channels = channels, # custom annotation
-                amplitude = None,    # custom annotation
                 times = t_start + sampling_period * df['index'].values,
                 t_start = t_start,
                 t_stop = t_stop,
+            )
+
+            st.annotate(
+                channels=channels,
+                amplitude=None,
             )
 
             spiketrain_list.append(st)
@@ -619,11 +622,14 @@ def _detect_spikes(sig, discriminator, epochs):
 
     st = neo.SpikeTrain(
         name = discriminator['name'],
-        channels = [discriminator['channel']],  # custom annotation
-        amplitude = pq.Quantity(discriminator['amplitude'], discriminator['units']), # custom annotation
         times = spikes_between_min_and_max * pq.s,
         t_start = sig.t_start,
         t_stop  = sig.t_stop,
+    )
+
+    st.annotate(
+        channels=[discriminator['channel']],
+        amplitude=pq.Quantity(discriminator['amplitude'], discriminator['units']),
     )
 
     if 'epoch' in discriminator:
@@ -648,6 +654,8 @@ def _detect_spikes(sig, discriminator, epochs):
         # select the subset of spikes that fall within the epoch
         # windows
         st = st[np.any(time_masks, axis=0)]
+
+        st.annotate(epoch=discriminator['epoch'])
 
     return st
 


### PR DESCRIPTION
The new `type` parameter allows the default types (peaks for amplitude windows with positive bounds; troughs for negative bounds) to be overridden. It also permits amplitude windows spanning zero (negative lower bound and positive upper bound), for which the type cannot be inferred.

This PR also adds an `"epoch"` annotation to a detected spike train if the amplitude discriminator filtered the spikes by epoch type.