### PR TITLE
Allow users to change CLI argument defaults in a global config file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include README.rst
 include requirements*.txt
 
 # package data included in source distribution and installation
+include neurotic/global_config_template.txt
 include neurotic/example/example-notebook.ipynb
 include neurotic/example/metadata.yml
 include neurotic/tests/metadata-for-tests.yml

--- a/README.rst
+++ b/README.rst
@@ -254,8 +254,10 @@ The command line interface accepts other arguments too:
 
 .. code-block::
 
-    usage: neurotic [-h] [-V] [--debug] [--no-lazy] [--thick-traces]
-                    [--show-datetime] [--ui-scale {tiny,small,medium,large,huge}]
+    usage: neurotic [-h] [-V] [--debug] [--no-debug] [--lazy] [--no-lazy]
+                    [--thick-traces] [--no-thick-traces] [--show-datetime]
+                    [--no-show-datetime]
+                    [--ui-scale {tiny,small,medium,large,huge}]
                     [--theme {light,dark,original,printer-friendly}]
                     [--launch-example-notebook]
                     [file] [dataset]
@@ -274,13 +276,16 @@ The command line interface accepts other arguments too:
       -h, --help            show this help message and exit
       -V, --version         show program's version number and exit
       --debug               enable detailed log messages for debugging
-      --no-lazy             do not use fast loading (default: use fast loading)
+      --no-debug            disable detailed log messages for debugging (default)
+      --lazy                enable fast loading (default)
+      --no-lazy             disable fast loading
       --thick-traces        enable support for traces with thick lines, which has
-                            a performance cost (default: disable thick line
-                            support)
+                            a performance cost
+      --no-thick-traces     disable support for traces with thick lines (default)
       --show-datetime       display the real-world date and time, which may be
                             inaccurate depending on file type and acquisition
-                            software (default: do not display)
+                            software
+      --no-show-datetime    do not display the real-world date and time (default)
       --ui-scale {tiny,small,medium,large,huge}
                             the scale of user interface elements, such as text
                             (default: medium)

--- a/README.rst
+++ b/README.rst
@@ -254,9 +254,9 @@ The command line interface accepts other arguments too:
 
 .. code-block::
 
-    usage: neurotic [-h] [-V] [--debug] [--no-debug] [--lazy] [--no-lazy]
-                    [--thick-traces] [--no-thick-traces] [--show-datetime]
-                    [--no-show-datetime]
+    usage: neurotic [-h] [-V] [--debug | --no-debug] [--lazy | --no-lazy]
+                    [--thick-traces | --no-thick-traces]
+                    [--show-datetime | --no-show-datetime]
                     [--ui-scale {tiny,small,medium,large,huge}]
                     [--theme {light,dark,original,printer-friendly}]
                     [--launch-example-notebook]
@@ -291,6 +291,8 @@ The command line interface accepts other arguments too:
                             (default: medium)
       --theme {light,dark,original,printer-friendly}
                             a color theme for the GUI (default: light)
+
+    alternative modes:
       --launch-example-notebook
                             launch Jupyter with an example notebook instead of
                             starting the standalone app (other args will be

--- a/README.rst
+++ b/README.rst
@@ -259,7 +259,7 @@ The command line interface accepts other arguments too:
                     [--show-datetime | --no-show-datetime]
                     [--ui-scale {tiny,small,medium,large,huge}]
                     [--theme {light,dark,original,printer-friendly}]
-                    [--launch-example-notebook]
+                    [--use-factory-defaults] [--launch-example-notebook]
                     [file] [dataset]
 
     neurotic lets you curate, visualize, annotate, and share your behavioral ephys
@@ -291,6 +291,9 @@ The command line interface accepts other arguments too:
                             (default: medium)
       --theme {light,dark,original,printer-friendly}
                             a color theme for the GUI (default: light)
+      --use-factory-defaults
+                            start with "factory default" settings, ignoring other
+                            args and your global config file
 
     alternative modes:
       --launch-example-notebook
@@ -298,8 +301,8 @@ The command line interface accepts other arguments too:
                             starting the standalone app (other args will be
                             ignored)
 
-    Defaults for arguments and options can be changed in
-    .neurotic/neurotic-config.txt, located in your home directory.
+    Defaults for arguments and options can be changed in a global config file,
+    .neurotic\neurotic-config.txt, located in your home directory.
 
 Citing *neurotic*
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -298,6 +298,9 @@ The command line interface accepts other arguments too:
                             starting the standalone app (other args will be
                             ignored)
 
+    Defaults for arguments and options can be changed in
+    .neurotic/neurotic-config.txt, located in your home directory.
+
 Citing *neurotic*
 -----------------
 

--- a/docs/globalconfig.rst
+++ b/docs/globalconfig.rst
@@ -1,0 +1,21 @@
+.. _global-config:
+
+Changing Default Behavior
+=========================
+
+Default parameters used by the command line interface for launching the app,
+such as which metadata file to open initially, can be configured using global
+configuration settings located in ``.neurotic/neurotic-config.txt`` in your
+home directory:
+
+ - Windows: ``C:\Users\<username>\.neurotic\neurotic-config.txt``
+ - macOS: ``/Users/<username>/.neurotic/neurotic-config.txt``
+ - Linux: ``/home/<username>/.neurotic/neurotic-config.txt``
+
+The file can be opened easily using the "View global config file" menu action.
+
+If this file does not exist when *neurotic* is launched, the following template
+is created for you:
+
+.. literalinclude:: ../neurotic/global_config_template.txt
+   :language: toml

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ at the same datasets!
    citations
    metadata
    examples
+   globalconfig
    api
    releasenotes
 

--- a/neurotic/__init__.py
+++ b/neurotic/__init__.py
@@ -7,6 +7,8 @@ Curate, visualize, annotate, and share your behavioral ephys data using Python
 
 import os
 import sys
+import shutil
+import pkg_resources
 import collections.abc
 import logging
 import logging.handlers
@@ -40,13 +42,13 @@ global_config = {
 global_config_file = os.path.join(neurotic_dir, 'neurotic-config.txt')
 
 if not os.path.exists(global_config_file):
-    # create a template global config file containing commented-out defaults
-    global_config_string = toml.dumps(global_config)
-    global_config_string = '\n'.join([f'# {s}' if s and not s.startswith('[') else s for s in global_config_string.split('\n')])
-    with open(global_config_file, 'w') as f:
-        f.write(global_config_string)
+    # copy a template global config file containing commented-out defaults
+    shutil.copy(
+        pkg_resources.resource_filename(
+            'neurotic', 'global_config_template.txt'),
+        global_config_file)
 
-def update_global_config_from_file():
+def update_global_config_from_file(file=global_config_file):
     """
     Update the global_config dictionary with data from the global config file,
     using recursion to traverse nested dictionaries.
@@ -58,7 +60,7 @@ def update_global_config_from_file():
             else:
                 d[k] = v
         return d
-    with open(global_config_file, 'r') as f:
+    with open(file, 'r') as f:
         update_dict(global_config, toml.loads(f.read()))
 
 update_global_config_from_file()

--- a/neurotic/__init__.py
+++ b/neurotic/__init__.py
@@ -24,6 +24,59 @@ neurotic_dir = os.path.join(os.path.expanduser('~'), '.neurotic')
 if not os.path.exists(neurotic_dir):
     os.mkdir(neurotic_dir)
 
+
+class FileLoggingFormatter(logging.Formatter):
+    """
+    A custom formatter for file logging
+    """
+    default_msec_format = '%s.%03d'  # use period radix point instead of comma in decimal seconds
+    def format(self, record):
+        if logging.getLogger(__name__).level <= logging.DEBUG:
+            # include more detail if the logger level (not the record level) is
+            # debug or lower
+            self._style._fmt = '[%(asctime)s] [%(levelname)-8s] [%(threadName)-10s] [%(name)s:%(lineno)d (%(funcName)s)] %(message)s'
+        else:
+            self._style._fmt = '[%(asctime)s] [%(levelname)-8s] %(message)s'
+        return super().format(record)
+
+class StreamLoggingFormatter(logging.Formatter):
+    """
+    A custom formatter for stream logging
+    """
+    def format(self, record):
+        if record.levelno == logging.INFO:
+            # exclude the level name ("INFO") from common log records
+            self._style._fmt = '[neurotic] %(message)s'
+        else:
+            self._style._fmt = '[neurotic] %(levelname)s: %(message)s'
+        return super().format(record)
+
+
+# set the file path for logging
+log_file = os.path.join(neurotic_dir, 'neurotic-log.txt')
+
+# set the default level for logging to INFO unless it was set to a custom level
+# before importing the package
+logger = logging.getLogger(__name__)
+if logger.level == logging.NOTSET:
+    default_log_level = logging.INFO
+    logger.setLevel(default_log_level)
+else:
+    default_log_level = logger.level
+
+# write log records to a file, rotating files if it exceeds 10 MB
+logger_filehandler = logging.handlers.RotatingFileHandler(filename=log_file, maxBytes=10000000, backupCount=2)
+logger_filehandler.setFormatter(FileLoggingFormatter())
+logger.addHandler(logger_filehandler)
+logger.info('===========================')        # file logger only
+logger.info(f'Importing neurotic {__version__}')  # file logger only
+
+# stream log records to stderr
+logger_streamhandler = logging.StreamHandler(stream=sys.stderr)
+logger_streamhandler.setFormatter(StreamLoggingFormatter())
+logger.addHandler(logger_streamhandler)
+
+
 global_config = {
     'defaults': {
         # defaults used by the command line interface
@@ -88,59 +141,6 @@ def update_global_config_from_file(file=global_config_file):
     """
     with open(file, 'r') as f:
         update_dict(global_config, toml.loads(f.read()))
-
-
-class FileLoggingFormatter(logging.Formatter):
-    """
-    A custom formatter for file logging
-    """
-    default_msec_format = '%s.%03d'  # use period radix point instead of comma in decimal seconds
-    def format(self, record):
-        if logging.getLogger(__name__).level <= logging.DEBUG:
-            # include more detail if the logger level (not the record level) is
-            # debug or lower
-            self._style._fmt = '[%(asctime)s] [%(levelname)-8s] [%(threadName)-10s] [%(name)s:%(lineno)d (%(funcName)s)] %(message)s'
-        else:
-            self._style._fmt = '[%(asctime)s] [%(levelname)-8s] %(message)s'
-        return super().format(record)
-
-class StreamLoggingFormatter(logging.Formatter):
-    """
-    A custom formatter for stream logging
-    """
-    def format(self, record):
-        if record.levelno == logging.INFO:
-            # exclude the level name ("INFO") from common log records
-            self._style._fmt = '[neurotic] %(message)s'
-        else:
-            self._style._fmt = '[neurotic] %(levelname)s: %(message)s'
-        return super().format(record)
-
-
-# set the file path for logging
-log_file = os.path.join(neurotic_dir, 'neurotic-log.txt')
-
-# set the default level for logging to INFO unless it was set to a custom level
-# before importing the package
-logger = logging.getLogger(__name__)
-if logger.level == logging.NOTSET:
-    default_log_level = logging.INFO
-    logger.setLevel(default_log_level)
-else:
-    default_log_level = logger.level
-
-# write log records to a file, rotating files if it exceeds 10 MB
-logger_filehandler = logging.handlers.RotatingFileHandler(filename=log_file, maxBytes=10000000, backupCount=2)
-logger_filehandler.setFormatter(FileLoggingFormatter())
-logger.addHandler(logger_filehandler)
-logger.info('===========================')        # file logger only
-logger.info(f'Importing neurotic {__version__}')  # file logger only
-
-# stream log records to stderr
-logger_streamhandler = logging.StreamHandler(stream=sys.stderr)
-logger_streamhandler.setFormatter(StreamLoggingFormatter())
-logger.addHandler(logger_streamhandler)
-
 
 try:
     update_global_config_from_file()

--- a/neurotic/__init__.py
+++ b/neurotic/__init__.py
@@ -19,6 +19,19 @@ neurotic_dir = os.path.join(os.path.expanduser('~'), '.neurotic')
 if not os.path.exists(neurotic_dir):
     os.mkdir(neurotic_dir)
 
+global_config = {
+    'defaults': {
+        # defaults used by the command line interface
+        'file': None,
+        'dataset': None,
+        'debug': False,
+        'lazy': True,
+        'thick_traces': False,
+        'show_datetime': False,
+        'ui_scale': 'medium',
+        'theme': 'light',
+    }
+}
 
 class FileLoggingFormatter(logging.Formatter):
     """

--- a/neurotic/__init__.py
+++ b/neurotic/__init__.py
@@ -5,14 +5,20 @@ NEUROscience Tool for Interactive Characterization
 Curate, visualize, annotate, and share your behavioral ephys data using Python
 """
 
-from .version import version as __version__
-from .version import git_revision as __git_revision__
-
-
 import os
 import sys
 import logging
 import logging.handlers
+
+from .version import version as __version__
+from .version import git_revision as __git_revision__
+
+
+# set the user's directory for logs
+neurotic_dir = os.path.join(os.path.expanduser('~'), '.neurotic')
+if not os.path.exists(neurotic_dir):
+    os.mkdir(neurotic_dir)
+
 
 class FileLoggingFormatter(logging.Formatter):
     """
@@ -42,10 +48,7 @@ class StreamLoggingFormatter(logging.Formatter):
 
 
 # set the file path for logging
-log_dir = os.path.join(os.path.expanduser('~'), '.neurotic')
-if not os.path.exists(log_dir):
-    os.mkdir(log_dir)
-log_file = os.path.join(log_dir, 'neurotic-log.txt')
+log_file = os.path.join(neurotic_dir, 'neurotic-log.txt')
 
 # set the default level for logging to INFO unless it was set to a custom level
 # before importing the package

--- a/neurotic/__init__.py
+++ b/neurotic/__init__.py
@@ -89,8 +89,6 @@ def update_global_config_from_file(file=global_config_file):
     with open(file, 'r') as f:
         update_dict(global_config, toml.loads(f.read()))
 
-update_global_config_from_file()
-
 
 class FileLoggingFormatter(logging.Formatter):
     """
@@ -142,6 +140,12 @@ logger.info(f'Importing neurotic {__version__}')  # file logger only
 logger_streamhandler = logging.StreamHandler(stream=sys.stderr)
 logger_streamhandler.setFormatter(StreamLoggingFormatter())
 logger.addHandler(logger_streamhandler)
+
+
+try:
+    update_global_config_from_file()
+except Exception as e:
+    logger.error(f'Ignoring global config file due to parsing error ({global_config_file}): {e}')
 
 
 from .datasets import *

--- a/neurotic/__init__.py
+++ b/neurotic/__init__.py
@@ -48,18 +48,40 @@ if not os.path.exists(global_config_file):
             'neurotic', 'global_config_template.txt'),
         global_config_file)
 
+def update_dict(d, d_new):
+    """
+    Recursively update the contents of a dictionary. Unlike dict.update(), this
+    function preserves items in inner dictionaries that are absent from d_new.
+
+    For example, if given
+
+    >>> d = {'x': 0, 'inner': {'a': 1, 'b': 2}}
+    >>> d_new = {'inner': {'c': 3}}
+
+    then using d.update(d_new) will entirely replace d['inner'] with
+    d_new['inner']:
+
+    >>> d.update(d_new)
+    >>> d == {'x': 0, 'inner': {'c': 3}}
+
+    In contrast, update_dict(d, d_new) will preserve items found in d['inner']
+    but not in d_new['inner']:
+
+    >>> update_dict(d, d_new)
+    >>> d == {'x': 0, 'inner': {'a': 1, 'b': 2, 'c': 3}}
+    """
+    for k_new, v_new in d_new.items():
+        if isinstance(v_new, collections.abc.Mapping):
+            d[k_new] = update_dict(d.get(k_new, {}), v_new)
+        else:
+            d[k_new] = v_new
+    return d
+
 def update_global_config_from_file(file=global_config_file):
     """
     Update the global_config dictionary with data from the global config file,
     using recursion to traverse nested dictionaries.
     """
-    def update_dict(d, u):
-        for k, v in u.items():
-            if isinstance(v, collections.abc.Mapping):
-                d[k] = update_dict(d.get(k, {}), v)
-            else:
-                d[k] = v
-        return d
     with open(file, 'r') as f:
         update_dict(global_config, toml.loads(f.read()))
 

--- a/neurotic/__init__.py
+++ b/neurotic/__init__.py
@@ -8,6 +8,7 @@ Curate, visualize, annotate, and share your behavioral ephys data using Python
 import os
 import sys
 import shutil
+import copy
 import pkg_resources
 import collections.abc
 import logging
@@ -36,6 +37,9 @@ global_config = {
         'theme': 'light',
     },
 }
+
+# keep a copy of the original config before it is modified
+_global_config_factory_defaults = copy.deepcopy(global_config)
 
 # the global config file is a text file in TOML format owned by the user that
 # allows alternate defaults to be specified to replace those in global_config

--- a/neurotic/global_config_template.txt
+++ b/neurotic/global_config_template.txt
@@ -1,0 +1,25 @@
+# --- neurotic global config --------------------------------------------------
+# Use this file to configure the way neurotic behaves. This file uses the TOML
+# format.
+
+[defaults]
+# When the app is launched, the following customizable defaults are used unless
+# overridden by command line arguments. Example uses include:
+#   - Uncomment the "file" parameter and insert the path to your favorite
+#     metadata file so that it always opens automatically
+#   - Uncomment the "lazy" parameter and set it to false to always disable fast
+#     loading, ensuring that expensive procedures like spike detection and
+#     filtering are performed by default
+# To open the example metadata file by default, either leave the "file"
+# parameter commented or set it to "example". To initially select the first
+# dataset in the file, either leave the "dataset" parameter commented or set it
+# to "none".
+
+# file = "example"
+# dataset = "none"
+# debug = false
+# lazy = true
+# thick_traces = false
+# show_datetime = false
+# ui_scale = "medium"
+# theme = "light"

--- a/neurotic/gui/standalone.py
+++ b/neurotic/gui/standalone.py
@@ -18,7 +18,7 @@ import quantities as pq
 import neo
 from ephyviewer import QT, QT_MODE
 
-from .. import __version__, _elephant_tools, default_log_level, log_file
+from .. import __version__, _elephant_tools, global_config_file, default_log_level, log_file
 from ..datasets import MetadataSelector, load_dataset
 from ..datasets.metadata import _selector_labels
 from ..gui.config import EphyviewerConfigurator, available_themes, available_ui_scales
@@ -220,6 +220,11 @@ class MainWindow(QT.QMainWindow):
         do_toggle_show_datetime.setCheckable(True)
         do_toggle_show_datetime.setChecked(self.show_datetime)
         do_toggle_show_datetime.triggered.connect(self.toggle_show_datetime)
+
+        options_menu.addSeparator()
+
+        do_view_global_config_file = options_menu.addAction('View global &config file')
+        do_view_global_config_file.triggered.connect(self.view_global_config_file)
 
         appearance_menu = menu_bar.addMenu(self.tr('&Appearance'))
 
@@ -423,6 +428,19 @@ class MainWindow(QT.QMainWindow):
             self.do_launch.setEnabled(True)
             self.metadata_selector.setEnabled(True)
             self.stacked_layout.setCurrentIndex(0)  # show metadata selector
+
+    def view_global_config_file(self):
+        """
+        Open the global config file in an editor.
+        """
+
+        try:
+            open_path_with_default_program(global_config_file)
+        except FileNotFoundError as e:
+            logger.error(f'The global config file was not found: {e}')
+            self.statusBar().showMessage('ERROR: The global config file could '
+                                         'not be found', msecs=5000)
+            return
 
     def toggle_debug_logging(self, checked):
         """

--- a/neurotic/scripts.py
+++ b/neurotic/scripts.py
@@ -17,7 +17,7 @@ import pkg_resources
 
 from ephyviewer import QT, mkQApp
 
-from . import __version__
+from . import __version__, default_log_level
 from .datasets.data import load_dataset
 from .gui.config import EphyviewerConfigurator, available_themes, available_ui_scales
 from .gui.standalone import MainWindow
@@ -61,17 +61,26 @@ def parse_args(argv):
                         version='neurotic {}'.format(__version__))
     parser.add_argument('--debug', action='store_true', dest='debug',
                         help='enable detailed log messages for debugging')
+    parser.add_argument('--no-debug', action='store_false', dest='debug',
+                        help='disable detailed log messages for debugging ' \
+                             '(default)')
+    parser.add_argument('--lazy', action='store_true', dest='lazy',
+                        help='enable fast loading (default)')
     parser.add_argument('--no-lazy', action='store_false', dest='lazy',
-                        help='do not use fast loading (default: use fast ' \
-                             'loading)')
+                        help='disable fast loading')
     parser.add_argument('--thick-traces', action='store_true', dest='thick_traces',
                         help='enable support for traces with thick lines, ' \
-                             'which has a performance cost (default: ' \
-                             'disable thick line support)')
+                             'which has a performance cost')
+    parser.add_argument('--no-thick-traces', action='store_false', dest='thick_traces',
+                        help='disable support for traces with thick lines ' \
+                             '(default)')
     parser.add_argument('--show-datetime', action='store_true', dest='show_datetime',
                         help='display the real-world date and time, which ' \
                              'may be inaccurate depending on file type and ' \
-                             'acquisition software (default: do not display)')
+                             'acquisition software')
+    parser.add_argument('--no-show-datetime', action='store_false', dest='show_datetime',
+                        help='do not display the real-world date and time ' \
+                             '(default)')
     parser.add_argument('--ui-scale', dest='ui_scale',
                         choices=available_ui_scales,
                         help='the scale of user interface elements, such as ' \
@@ -97,6 +106,17 @@ def parse_args(argv):
             # show only if Jupyter won't be launched, since the setting will
             # not carry over into the kernel started by Jupyter
             logger.debug('Debug messages enabled')
+
+    else:
+        # this should only be necessary if parse_args is called with --no-debug
+        # after having previously enabled debug messages in the current session
+        # (such as during unit testing)
+
+        logger.parent.setLevel(default_log_level)
+
+        # raise the threshold for PyAV messages printed to the console from
+        # warning to critical
+        logging.getLogger('libav').setLevel(logging.CRITICAL)
 
     return args
 

--- a/neurotic/scripts.py
+++ b/neurotic/scripts.py
@@ -52,6 +52,7 @@ def parse_args(argv):
     parser.add_argument('file', nargs='?',
                         help='the path to a metadata YAML file (default: an ' \
                              'example file)')
+
     parser.add_argument('dataset', nargs='?',
                         help='the name of a dataset in the metadata file to ' \
                              'select initially (default: the first entry in ' \
@@ -59,39 +60,50 @@ def parse_args(argv):
 
     parser.add_argument('-V', '--version', action='version',
                         version='neurotic {}'.format(__version__))
-    parser.add_argument('--debug', action='store_true', dest='debug',
-                        help='enable detailed log messages for debugging')
-    parser.add_argument('--no-debug', action='store_false', dest='debug',
-                        help='disable detailed log messages for debugging ' \
-                             '(default)')
-    parser.add_argument('--lazy', action='store_true', dest='lazy',
-                        help='enable fast loading (default)')
-    parser.add_argument('--no-lazy', action='store_false', dest='lazy',
-                        help='disable fast loading')
-    parser.add_argument('--thick-traces', action='store_true', dest='thick_traces',
-                        help='enable support for traces with thick lines, ' \
-                             'which has a performance cost')
-    parser.add_argument('--no-thick-traces', action='store_false', dest='thick_traces',
-                        help='disable support for traces with thick lines ' \
-                             '(default)')
-    parser.add_argument('--show-datetime', action='store_true', dest='show_datetime',
-                        help='display the real-world date and time, which ' \
-                             'may be inaccurate depending on file type and ' \
-                             'acquisition software')
-    parser.add_argument('--no-show-datetime', action='store_false', dest='show_datetime',
-                        help='do not display the real-world date and time ' \
-                             '(default)')
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--debug', action='store_true', dest='debug',
+                       help='enable detailed log messages for debugging')
+    group.add_argument('--no-debug', action='store_false', dest='debug',
+                       help='disable detailed log messages for debugging ' \
+                            '(default)')
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--lazy', action='store_true', dest='lazy',
+                       help='enable fast loading (default)')
+    group.add_argument('--no-lazy', action='store_false', dest='lazy',
+                       help='disable fast loading')
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--thick-traces', action='store_true', dest='thick_traces',
+                       help='enable support for traces with thick lines, ' \
+                            'which has a performance cost')
+    group.add_argument('--no-thick-traces', action='store_false', dest='thick_traces',
+                       help='disable support for traces with thick lines ' \
+                            '(default)')
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--show-datetime', action='store_true', dest='show_datetime',
+                       help='display the real-world date and time, which ' \
+                            'may be inaccurate depending on file type and ' \
+                            'acquisition software')
+    group.add_argument('--no-show-datetime', action='store_false', dest='show_datetime',
+                       help='do not display the real-world date and time ' \
+                            '(default)')
+
     parser.add_argument('--ui-scale', dest='ui_scale',
                         choices=available_ui_scales,
                         help='the scale of user interface elements, such as ' \
                              'text (default: medium)')
+
     parser.add_argument('--theme', choices=available_themes, dest='theme',
                         help='a color theme for the GUI (default: light)')
 
-    parser.add_argument('--launch-example-notebook', action='store_true',
-                        help='launch Jupyter with an example notebook ' \
-                             'instead of starting the standalone app (other ' \
-                             'args will be ignored)')
+    group = parser.add_argument_group('alternative modes')
+    group.add_argument('--launch-example-notebook', action='store_true',
+                       help='launch Jupyter with an example notebook ' \
+                            'instead of starting the standalone app (other ' \
+                            'args will be ignored)')
 
     args = parser.parse_args(argv[1:])
 

--- a/neurotic/scripts.py
+++ b/neurotic/scripts.py
@@ -50,13 +50,13 @@ def parse_args(argv):
     parser.set_defaults(**defaults)
 
     parser.add_argument('file', nargs='?',
-                        help='the path to a metadata YAML file (default: an '
-                             'example file)')
+                        help='the path to a metadata YAML file'
+                             f' (default: {"an example file" if defaults["file"] is None else defaults["file"]})')
 
     parser.add_argument('dataset', nargs='?',
                         help='the name of a dataset in the metadata file to '
-                             'select initially (default: the first entry in '
-                             'the metadata file)')
+                             'select initially'
+                             f' (default: {"the first entry in the metadata file" if defaults["dataset"] is None else defaults["dataset"]})')
 
     parser.add_argument('-V', '--version',
                         action='version',
@@ -65,49 +65,56 @@ def parse_args(argv):
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--debug', dest='debug',
                        action='store_true',
-                       help='enable detailed log messages for debugging')
+                       help='enable detailed log messages for debugging'
+                            f'{" (default)" if defaults["debug"] else ""}')
     group.add_argument('--no-debug', dest='debug',
                        action='store_false',
-                       help='disable detailed log messages for debugging '
-                            '(default)')
+                       help='disable detailed log messages for debugging'
+                            f'{" (default)" if not defaults["debug"] else ""}')
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--lazy', dest='lazy',
                        action='store_true',
-                       help='enable fast loading (default)')
+                       help='enable fast loading'
+                            f'{" (default)" if defaults["lazy"] else ""}')
     group.add_argument('--no-lazy', dest='lazy',
                        action='store_false',
-                       help='disable fast loading')
+                       help='disable fast loading'
+                            f'{" (default)" if not defaults["lazy"] else ""}')
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--thick-traces', dest='thick_traces',
                        action='store_true',
                        help='enable support for traces with thick lines, '
-                            'which has a performance cost')
+                            'which has a performance cost'
+                            f'{" (default)" if defaults["thick_traces"] else ""}')
     group.add_argument('--no-thick-traces', dest='thick_traces',
                        action='store_false',
-                       help='disable support for traces with thick lines '
-                            '(default)')
+                       help='disable support for traces with thick lines'
+                            f'{" (default)" if not defaults["thick_traces"] else ""}')
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--show-datetime', dest='show_datetime',
                        action='store_true',
                        help='display the real-world date and time, which '
                             'may be inaccurate depending on file type and '
-                            'acquisition software')
+                            'acquisition software'
+                            f'{" (default)" if defaults["show_datetime"] else ""}')
     group.add_argument('--no-show-datetime', dest='show_datetime',
                        action='store_false',
-                       help='do not display the real-world date and time '
-                            '(default)')
+                       help='do not display the real-world date and time'
+                            f'{" (default)" if not defaults["show_datetime"] else ""}')
 
     parser.add_argument('--ui-scale', dest='ui_scale',
                         choices=available_ui_scales,
                         help='the scale of user interface elements, such as '
-                             'text (default: medium)')
+                             'text'
+                             f' (default: {defaults["ui_scale"]})')
 
     parser.add_argument('--theme', dest='theme',
                         choices=available_themes,
-                        help='a color theme for the GUI (default: light)')
+                        help='a color theme for the GUI'
+                             f' (default: {defaults["theme"]})')
 
     group = parser.add_argument_group('alternative modes')
     group.add_argument('--launch-example-notebook',

--- a/neurotic/scripts.py
+++ b/neurotic/scripts.py
@@ -37,10 +37,22 @@ def parse_args(argv):
     """
     parser = argparse.ArgumentParser(description=description)
 
-    parser.add_argument('file', nargs='?', default=None,
+    defaults = {
+        'file': None,
+        'dataset': None,
+        'debug': False,
+        'lazy': True,
+        'thick_traces': False,
+        'show_datetime': False,
+        'ui_scale': 'medium',
+        'theme': 'light',
+    }
+    parser.set_defaults(**defaults)
+
+    parser.add_argument('file', nargs='?',
                         help='the path to a metadata YAML file (default: an ' \
                              'example file)')
-    parser.add_argument('dataset', nargs='?', default=None,
+    parser.add_argument('dataset', nargs='?',
                         help='the name of a dataset in the metadata file to ' \
                              'select initially (default: the first entry in ' \
                              'the metadata file)')
@@ -52,19 +64,19 @@ def parse_args(argv):
     parser.add_argument('--no-lazy', action='store_false', dest='lazy',
                         help='do not use fast loading (default: use fast ' \
                              'loading)')
-    parser.add_argument('--thick-traces', action='store_true', dest='thick',
+    parser.add_argument('--thick-traces', action='store_true', dest='thick_traces',
                         help='enable support for traces with thick lines, ' \
                              'which has a performance cost (default: ' \
                              'disable thick line support)')
-    parser.add_argument('--show-datetime', action='store_true', dest='datetime',
+    parser.add_argument('--show-datetime', action='store_true', dest='show_datetime',
                         help='display the real-world date and time, which ' \
                              'may be inaccurate depending on file type and ' \
                              'acquisition software (default: do not display)')
     parser.add_argument('--ui-scale', dest='ui_scale',
-                        choices=available_ui_scales, default='medium',
+                        choices=available_ui_scales,
                         help='the scale of user interface elements, such as ' \
                              'text (default: medium)')
-    parser.add_argument('--theme', choices=available_themes, default='light',
+    parser.add_argument('--theme', choices=available_themes, dest='theme',
                         help='a color theme for the GUI (default: light)')
 
     parser.add_argument('--launch-example-notebook', action='store_true',
@@ -95,8 +107,8 @@ def win_from_args(args):
 
     win = MainWindow(file=args.file, initial_selection=args.dataset,
                      lazy=args.lazy, theme=args.theme, ui_scale=args.ui_scale,
-                     support_increased_line_width=args.thick,
-                     show_datetime=args.datetime)
+                     support_increased_line_width=args.thick_traces,
+                     show_datetime=args.show_datetime)
     return win
 
 def launch_example_notebook():

--- a/neurotic/scripts.py
+++ b/neurotic/scripts.py
@@ -169,6 +169,9 @@ def parse_args(argv):
         # warning to critical
         logging.getLogger('libav').setLevel(logging.CRITICAL)
 
+    logger.debug(f'Global config: {global_config}')
+    logger.debug(f'Parsed arguments: {args}')
+
     return args
 
 def win_from_args(args):

--- a/neurotic/scripts.py
+++ b/neurotic/scripts.py
@@ -17,7 +17,7 @@ import pkg_resources
 
 from ephyviewer import QT, mkQApp
 
-from . import __version__, default_log_level
+from . import __version__, global_config, default_log_level
 from .datasets.data import load_dataset
 from .gui.config import EphyviewerConfigurator, available_themes, available_ui_scales
 from .gui.standalone import MainWindow
@@ -37,16 +37,7 @@ def parse_args(argv):
     """
     parser = argparse.ArgumentParser(description=description)
 
-    defaults = {
-        'file': None,
-        'dataset': None,
-        'debug': False,
-        'lazy': True,
-        'thick_traces': False,
-        'show_datetime': False,
-        'ui_scale': 'medium',
-        'theme': 'light',
-    }
+    defaults = global_config['defaults']
     parser.set_defaults(**defaults)
 
     parser.add_argument('file', nargs='?',

--- a/neurotic/scripts.py
+++ b/neurotic/scripts.py
@@ -50,59 +50,70 @@ def parse_args(argv):
     parser.set_defaults(**defaults)
 
     parser.add_argument('file', nargs='?',
-                        help='the path to a metadata YAML file (default: an ' \
+                        help='the path to a metadata YAML file (default: an '
                              'example file)')
 
     parser.add_argument('dataset', nargs='?',
-                        help='the name of a dataset in the metadata file to ' \
-                             'select initially (default: the first entry in ' \
+                        help='the name of a dataset in the metadata file to '
+                             'select initially (default: the first entry in '
                              'the metadata file)')
 
-    parser.add_argument('-V', '--version', action='version',
+    parser.add_argument('-V', '--version',
+                        action='version',
                         version='neurotic {}'.format(__version__))
 
     group = parser.add_mutually_exclusive_group()
-    group.add_argument('--debug', action='store_true', dest='debug',
+    group.add_argument('--debug', dest='debug',
+                       action='store_true',
                        help='enable detailed log messages for debugging')
-    group.add_argument('--no-debug', action='store_false', dest='debug',
-                       help='disable detailed log messages for debugging ' \
+    group.add_argument('--no-debug', dest='debug',
+                       action='store_false',
+                       help='disable detailed log messages for debugging '
                             '(default)')
 
     group = parser.add_mutually_exclusive_group()
-    group.add_argument('--lazy', action='store_true', dest='lazy',
+    group.add_argument('--lazy', dest='lazy',
+                       action='store_true',
                        help='enable fast loading (default)')
-    group.add_argument('--no-lazy', action='store_false', dest='lazy',
+    group.add_argument('--no-lazy', dest='lazy',
+                       action='store_false',
                        help='disable fast loading')
 
     group = parser.add_mutually_exclusive_group()
-    group.add_argument('--thick-traces', action='store_true', dest='thick_traces',
-                       help='enable support for traces with thick lines, ' \
+    group.add_argument('--thick-traces', dest='thick_traces',
+                       action='store_true',
+                       help='enable support for traces with thick lines, '
                             'which has a performance cost')
-    group.add_argument('--no-thick-traces', action='store_false', dest='thick_traces',
-                       help='disable support for traces with thick lines ' \
+    group.add_argument('--no-thick-traces', dest='thick_traces',
+                       action='store_false',
+                       help='disable support for traces with thick lines '
                             '(default)')
 
     group = parser.add_mutually_exclusive_group()
-    group.add_argument('--show-datetime', action='store_true', dest='show_datetime',
-                       help='display the real-world date and time, which ' \
-                            'may be inaccurate depending on file type and ' \
+    group.add_argument('--show-datetime', dest='show_datetime',
+                       action='store_true',
+                       help='display the real-world date and time, which '
+                            'may be inaccurate depending on file type and '
                             'acquisition software')
-    group.add_argument('--no-show-datetime', action='store_false', dest='show_datetime',
-                       help='do not display the real-world date and time ' \
+    group.add_argument('--no-show-datetime', dest='show_datetime',
+                       action='store_false',
+                       help='do not display the real-world date and time '
                             '(default)')
 
     parser.add_argument('--ui-scale', dest='ui_scale',
                         choices=available_ui_scales,
-                        help='the scale of user interface elements, such as ' \
+                        help='the scale of user interface elements, such as '
                              'text (default: medium)')
 
-    parser.add_argument('--theme', choices=available_themes, dest='theme',
+    parser.add_argument('--theme', dest='theme',
+                        choices=available_themes,
                         help='a color theme for the GUI (default: light)')
 
     group = parser.add_argument_group('alternative modes')
-    group.add_argument('--launch-example-notebook', action='store_true',
-                       help='launch Jupyter with an example notebook ' \
-                            'instead of starting the standalone app (other ' \
+    group.add_argument('--launch-example-notebook',
+                       action='store_true',
+                       help='launch Jupyter with an example notebook '
+                            'instead of starting the standalone app (other '
                             'args will be ignored)')
 
     args = parser.parse_args(argv[1:])

--- a/neurotic/scripts.py
+++ b/neurotic/scripts.py
@@ -18,7 +18,7 @@ import pkg_resources
 
 from ephyviewer import QT, mkQApp
 
-from . import __version__, global_config, global_config_file, default_log_level
+from . import __version__, global_config, _global_config_factory_defaults, global_config_file, default_log_level
 from .datasets.data import load_dataset
 from .gui.config import EphyviewerConfigurator, available_themes, available_ui_scales
 from .gui.standalone import MainWindow
@@ -38,7 +38,7 @@ def parse_args(argv):
     """
 
     epilog = f"""
-    Defaults for arguments and options can be changed in
+    Defaults for arguments and options can be changed in a global config file,
     {os.path.relpath(global_config_file, os.path.expanduser('~'))}, located in
     your home directory.
     """
@@ -115,6 +115,11 @@ def parse_args(argv):
                         help='a color theme for the GUI'
                              f' (default: {defaults["theme"]})')
 
+    parser.add_argument('--use-factory-defaults',
+                        action='store_true',
+                        help='start with "factory default" settings, ignoring '
+                             'other args and your global config file')
+
     group = parser.add_argument_group('alternative modes')
     group.add_argument('--launch-example-notebook',
                        action='store_true',
@@ -123,6 +128,11 @@ def parse_args(argv):
                             'args will be ignored)')
 
     args = parser.parse_args(argv[1:])
+
+    if args.use_factory_defaults:
+        # replace every argument with the factory default
+        for k, v in _global_config_factory_defaults['defaults'].items():
+            setattr(args, k, v)
 
     # these special values for the positional arguments can be used to override
     # the defaults set in the global config file with the defaults normally set

--- a/neurotic/tests/test_cli.py
+++ b/neurotic/tests/test_cli.py
@@ -62,6 +62,34 @@ class CLITestCase(unittest.TestCase):
         neurotic.global_config.clear()
         neurotic.global_config.update(self.original_config)
 
+    def test_global_config_template(self):
+        """Test that the global config template matches the factory defaults"""
+
+        # load the template global config file by first copying it to the temp
+        # directory, uncommenting every parameter, and then updating
+        # global_config using the modified file
+        self.template_global_config_file = pkg_resources.resource_filename(
+            'neurotic', 'global_config_template.txt')
+        self.temp_global_config_file = shutil.copy(
+            self.template_global_config_file, self.temp_dir.name)
+        with fileinput.input(self.temp_global_config_file, inplace=True) as f:
+            for line in f:
+                if re.match('#.*=.*', line):
+                    line = line[1:]
+                print(line, end='')  # stdout is redirected into the file
+        neurotic.update_global_config_from_file(self.temp_global_config_file)
+
+        # substitute special values
+        if neurotic.global_config['defaults']['file'] == 'example':
+            neurotic.global_config['defaults']['file'] = None
+        if neurotic.global_config['defaults']['dataset'] == 'none':
+            neurotic.global_config['defaults']['dataset'] = None
+
+        self.assertEqual(neurotic.global_config,
+                         neurotic._global_config_factory_defaults,
+                         'global_config loaded from template global config '
+                         'file differs from factory defaults')
+
     def test_cli_installed(self):
         """Test that the command line interface is installed"""
         self.assertIsNotNone(shutil.which('neurotic'), 'path to cli not found')

--- a/neurotic/tests/test_cli.py
+++ b/neurotic/tests/test_cli.py
@@ -93,6 +93,23 @@ class CLITestCase(unittest.TestCase):
         self.assertTrue(win.do_toggle_debug_logging.isChecked(),
                         'debug logging disabled with --debug')
 
+    def test_no_debug(self):
+        """Test that --no-debug disables logging of debug messages"""
+        argv = ['neurotic', '--no-debug']
+        args = neurotic.parse_args(argv)
+        app = mkQApp()
+        win = neurotic.win_from_args(args)
+        self.assertFalse(win.do_toggle_debug_logging.isChecked(),
+                         'debug logging enabled with --no-debug')
+
+    def test_lazy(self):
+        """Test that --lazy enables lazy loading"""
+        argv = ['neurotic', '--lazy']
+        args = neurotic.parse_args(argv)
+        app = mkQApp()
+        win = neurotic.win_from_args(args)
+        self.assertTrue(win.lazy, 'lazy loading disbled with --lazy')
+
     def test_no_lazy(self):
         """Test that --no-lazy disables lazy loading"""
         argv = ['neurotic', '--no-lazy']
@@ -110,6 +127,15 @@ class CLITestCase(unittest.TestCase):
         self.assertTrue(win.support_increased_line_width,
                         'thick traces disabled with --thick-traces')
 
+    def test_no_thick_traces(self):
+        """Test that --no-thick-traces disables support for thick traces"""
+        argv = ['neurotic', '--no-thick-traces']
+        args = neurotic.parse_args(argv)
+        app = mkQApp()
+        win = neurotic.win_from_args(args)
+        self.assertFalse(win.support_increased_line_width,
+                         'thick traces enabled with --no-thick-traces')
+
     def test_show_datetime(self):
         """Test that --show-datetime enables display of real-world datetime"""
         argv = ['neurotic', '--show-datetime']
@@ -118,6 +144,15 @@ class CLITestCase(unittest.TestCase):
         win = neurotic.win_from_args(args)
         self.assertTrue(win.show_datetime,
                         'datetime not displayed with --show-datetime')
+
+    def test_no_show_datetime(self):
+        """Test that --no-show-datetime hides the real-world datetime"""
+        argv = ['neurotic', '--no-show-datetime']
+        args = neurotic.parse_args(argv)
+        app = mkQApp()
+        win = neurotic.win_from_args(args)
+        self.assertFalse(win.show_datetime,
+                         'datetime displayed with --no-show-datetime')
 
     def test_ui_scale(self):
         """Test that --ui-scale changes the ui_scale"""

--- a/neurotic/tests/test_cli.py
+++ b/neurotic/tests/test_cli.py
@@ -228,6 +228,16 @@ class CLITestCase(unittest.TestCase):
             win = neurotic.win_from_args(args)
             self.assertEqual(win.theme, theme, 'unexpected theme')
 
+    def test_use_factory_defaults(self):
+        """Test that --use-factory-defaults resets all defaults"""
+        for k in neurotic.global_config['defaults']:
+            neurotic.global_config['defaults'][k] = 'bad value'
+        argv = ['neurotic', '--use-factory-defaults']
+        args = neurotic.parse_args(argv)
+        for k, v in neurotic._global_config_factory_defaults['defaults'].items():
+            self.assertEqual(getattr(args, k), v,
+                             f'args.{k} was not reset to factory default')
+
     def test_file(self):
         """Test that metadata file can be set"""
         argv = ['neurotic', self.temp_file]

--- a/neurotic/tests/test_cli.py
+++ b/neurotic/tests/test_cli.py
@@ -24,25 +24,30 @@ logger = logging.getLogger(__name__)
 class CLITestCase(unittest.TestCase):
 
     def setUp(self):
-        self.default_file = pkg_resources.resource_filename(
+        self.default_config = copy.deepcopy(neurotic.global_config)
+        self.example_file = pkg_resources.resource_filename(
             'neurotic', 'example/metadata.yml')
-        self.default_dataset = 'Aplysia feeding'
+        self.example_dataset = 'Aplysia feeding'
 
         # make a copy of the default file in a temp directory
         self.temp_dir = tempfile.TemporaryDirectory(prefix='neurotic-')
-        self.temp_file = shutil.copy(self.default_file, self.temp_dir.name)
+        self.temp_file = shutil.copy(self.example_file, self.temp_dir.name)
 
-        # add a second dataset
+        # add another dataset to the example
         with open(self.temp_file) as f:
             metadata = yaml.safe_load(f)
-        metadata['zzz_alphabetically_last'] = copy.deepcopy(
-            metadata['Aplysia feeding'])
+        self.duplicate_dataset = 'zzz_alphabetically_last'
+        metadata[self.duplicate_dataset] = copy.deepcopy(
+            metadata[self.example_dataset])
         with open(self.temp_file, 'w') as f:
             f.write(yaml.dump(metadata))
 
     def tearDown(self):
         # remove the temp directory
         self.temp_dir.cleanup()
+
+        # restore the original global config
+        neurotic.global_config = copy.deepcopy(self.default_config)
 
     def test_cli_installed(self):
         """Test that the command line interface is installed"""
@@ -68,20 +73,30 @@ class CLITestCase(unittest.TestCase):
         args = neurotic.parse_args(argv)
         app = mkQApp()
         win = neurotic.win_from_args(args)
-        self.assertFalse(win.do_toggle_debug_logging.isChecked(),
-                         'debug logging enabled without --debug')
-        self.assertTrue(win.lazy, 'lazy loading disabled without --no-lazy')
-        self.assertFalse(win.support_increased_line_width,
-                         'thick traces enabled without --thick-traces')
-        self.assertFalse(win.show_datetime,
-                         'datetime enabled without --show-datetime')
-        self.assertEqual(win.ui_scale, 'medium',
-                         'ui_scale changed without --ui-scale')
-        self.assertEqual(win.theme, 'light', 'theme changed without --theme')
-        self.assertEqual(win.metadata_selector.file, self.default_file,
+        defaults = neurotic.global_config['defaults']
+        self.assertEqual(win.do_toggle_debug_logging.isChecked(),
+                         defaults['debug'],
+                         'debug logging setting did not match default')
+        self.assertEqual(win.lazy,
+                         defaults['lazy'],
+                         'lazy loading setting did not match default')
+        self.assertEqual(win.support_increased_line_width,
+                         defaults['thick_traces'],
+                         'thick traces setting did not match default')
+        self.assertEqual(win.show_datetime,
+                         defaults['show_datetime'],
+                         'datetime setting did not match default')
+        self.assertEqual(win.ui_scale,
+                         defaults['ui_scale'],
+                         'ui scale did not match default')
+        self.assertEqual(win.theme,
+                         defaults['theme'],
+                         'theme did not match default')
+        self.assertEqual(win.metadata_selector.file,
+                         self.example_file if defaults['file'] is None else defaults['file'],
                          'file was not set to default')
         self.assertEqual(win.metadata_selector._selection,
-                         self.default_dataset,
+                         self.example_dataset if defaults['dataset'] is None else defaults['dataset'],
                          'dataset was not set to default dataset')
 
     def test_debug(self):
@@ -176,7 +191,7 @@ class CLITestCase(unittest.TestCase):
 
     def test_file(self):
         """Test that metadata file can be set"""
-        argv = ['neurotic', self.temp_file]
+        argv = ['neurotic', self.temp_file, 'none']
         args = neurotic.parse_args(argv)
         win = neurotic.win_from_args(args)
         self.assertEqual(win.metadata_selector.file, self.temp_file,
@@ -184,11 +199,24 @@ class CLITestCase(unittest.TestCase):
 
     def test_dataset(self):
         """Test that dataset can be set"""
-        argv = ['neurotic', self.temp_file, 'zzz_alphabetically_last']
+        argv = ['neurotic', self.temp_file, self.duplicate_dataset]
         args = neurotic.parse_args(argv)
         win = neurotic.win_from_args(args)
         self.assertEqual(win.metadata_selector._selection,
-                         'zzz_alphabetically_last',
+                         self.duplicate_dataset,
+                         'dataset was not changed correctly')
+
+    def test_example_file_and_first_dataset_overrides(self):
+        """Test that 'example' and 'none' open first dataset in example file"""
+        neurotic.global_config['defaults']['file'] = 'some other file'
+        neurotic.global_config['defaults']['dataset'] = 'some other dataset'
+        argv = ['neurotic', 'example', 'none']
+        args = neurotic.parse_args(argv)
+        win = neurotic.win_from_args(args)
+        self.assertEqual(win.metadata_selector.file, self.example_file,
+                         'file was not changed correctly')
+        self.assertEqual(win.metadata_selector._selection,
+                         self.example_dataset,
                          'dataset was not changed correctly')
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ quantities
 requests
 scipy
 setuptools
+toml
 tqdm


### PR DESCRIPTION
Users can now customize some default settings for the app and command line interface using a personal settings file, called the global configuration file. For example, the global config file lets you specify which metadata file is opened by default when the app first launches, or whether the "Fast loading" setting is checked or unchecked by default.

The first time *neurotic* is started or imported, a template for the global config file will be copied to your home directory (in `~/.neurotic`). The file is easy to locate for modification using the "View global config file" menu action.

See the documentation for more details.

Additionally, new command line interface flags were added which were not previously needed (e.g., `--lazy`, which was already the default) but are now useful if the default has been changed in the global config file and you wish to override it.

Finally, a new `--use-factory-defaults` flag can be used for ignoring the global config file.