### PR TITLE
Remove note about pyqtgraph incompatibility with Python 3.8 on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,11 +99,6 @@ Installing *neurotic*
 
 *neurotic* requires Python 3.6 or later.
 
-Note that the latest release of one of *neurotic*'s dependencies, pyqtgraph
-0.10.0, is incompatible with Python 3.8 or later on Windows unless that
-dependency is installed via conda-forge (recommended method) (`details
-<https://github.com/jpgill86/neurotic/issues/129>`_).
-
 Standalone Installers (recommended for beginners)
 .................................................
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,11 +5,6 @@ Installing *neurotic*
 
 *neurotic* requires Python 3.6 or later.
 
-Note that the latest release of one of *neurotic*'s dependencies, pyqtgraph
-0.10.0, is incompatible with Python 3.8 or later on Windows unless that
-dependency is installed via conda-forge (recommended method) (:issue:`details
-<129>`).
-
 .. _installation-installers:
 
 Standalone Installers (recommended for beginners)


### PR DESCRIPTION
pyqtgraph 0.11.0 was released in June 2020 with a fix for the compatibility issue. See also #129.