### PR TITLE
Exclude py files not part of the main package from coverage reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+# configuration of coverage.py
+# https://coverage.readthedocs.io
+
+[report]
+omit =
+    neurotic/gui/icons/make_resources.py
+    neurotic/tests/*


### PR DESCRIPTION
This will cause a significant coverage drop, since `test_*.py` files with high coverage will be excluded.