### PR TITLE
Better syntax for using factory defaults for file and dataset parameters in global config file and with CLI

### DIFF
--- a/neurotic/__init__.py
+++ b/neurotic/__init__.py
@@ -80,8 +80,8 @@ logger.addHandler(logger_streamhandler)
 global_config = {
     'defaults': {
         # defaults used by the command line interface
-        'file': None,
-        'dataset': None,
+        'file': False,
+        'dataset': False,
         'debug': False,
         'lazy': True,
         'thick_traces': False,

--- a/neurotic/global_config_template.txt
+++ b/neurotic/global_config_template.txt
@@ -14,10 +14,10 @@
 # To open the example metadata file by default, either leave the "file"
 # parameter commented or set it to "example". To initially select the first
 # dataset in the file, either leave the "dataset" parameter commented or set it
-# to "none".
+# to "first".
 
 # file = "example"
-# dataset = "none"
+# dataset = "first"
 # debug = false
 # lazy = true
 # thick_traces = false

--- a/neurotic/global_config_template.txt
+++ b/neurotic/global_config_template.txt
@@ -12,12 +12,12 @@
 #     loading, ensuring that expensive procedures like spike detection and
 #     filtering are performed by default
 # To open the example metadata file by default, either leave the "file"
-# parameter commented or set it to "example". To initially select the first
-# dataset in the file, either leave the "dataset" parameter commented or set it
-# to "first".
+# parameter unset, set it to false, or set it to "example". To initially select
+# the first dataset in the file, either leave the "dataset" parameter unset,
+# set it to false, or set it to "first".
 
-# file = "example"
-# dataset = "first"
+# file = false
+# dataset = false
 # debug = false
 # lazy = true
 # thick_traces = false
@@ -33,7 +33,7 @@
 #     authorization, so that permissions only need to be granted once. This is
 #     not recommended if others you do not trust have access to this computer,
 #     as it could let them download files from your Google Drive account.
-#   - Set "save_tokens" to false or leave it commented to forget access
+#   - Set "save_tokens" to false or leave it unset to forget access
 #     authorization after neurotic closes. Each time you restart neurotic, you
 #     will be required to re-grant permissions when you download a Google Drive
 #     file.

--- a/neurotic/gui/standalone.py
+++ b/neurotic/gui/standalone.py
@@ -145,7 +145,7 @@ class MainWindow(QT.QMainWindow):
         self.create_menus()
 
         # open metadata file
-        if file is not None:
+        if file:
             # try the user-specified file
             self.metadata_selector.file = file
             self.metadata_selector.load()
@@ -156,7 +156,7 @@ class MainWindow(QT.QMainWindow):
             self.metadata_selector.load()
 
         # select a dataset if the user provided one
-        if initial_selection is not None:
+        if initial_selection:
             try:
                 self.metadata_selector.setCurrentRow(list(self.metadata_selector.all_metadata).index(initial_selection))
             except (TypeError, ValueError) as e:

--- a/neurotic/scripts.py
+++ b/neurotic/scripts.py
@@ -50,12 +50,12 @@ def parse_args(argv):
 
     parser.add_argument('file', nargs='?',
                         help='the path to a metadata YAML file'
-                             f' (default: {"an example file" if defaults["file"] in [None, "example"] else defaults["file"] + "; to force the example, use: example"})')
+                             f' (default: {"an example file" if defaults["file"] in [False, "example"] else defaults["file"] + "; to force the example, use: example"})')
 
     parser.add_argument('dataset', nargs='?',
                         help='the name of a dataset in the metadata file to '
                              'select initially'
-                             f' (default: {"the first entry in the metadata file" if defaults["dataset"] in [None, "first"] else defaults["dataset"] + "; to force the first, use: - first"})')
+                             f' (default: {"the first entry in the metadata file" if defaults["dataset"] in [False, "first"] else defaults["dataset"] + "; to force the first, use: - first"})')
 
     parser.add_argument('-V', '--version',
                         action='version',

--- a/neurotic/scripts.py
+++ b/neurotic/scripts.py
@@ -50,12 +50,12 @@ def parse_args(argv):
 
     parser.add_argument('file', nargs='?',
                         help='the path to a metadata YAML file'
-                             f' (default: {"an example file" if defaults["file"] is None else defaults["file"] + "; to force the example, use: example"})')
+                             f' (default: {"an example file" if defaults["file"] in [None, "example"] else defaults["file"] + "; to force the example, use: example"})')
 
     parser.add_argument('dataset', nargs='?',
                         help='the name of a dataset in the metadata file to '
                              'select initially'
-                             f' (default: {"the first entry in the metadata file" if defaults["dataset"] is None else defaults["dataset"] + "; to force the first, use: - first"})')
+                             f' (default: {"the first entry in the metadata file" if defaults["dataset"] in [None, "first"] else defaults["dataset"] + "; to force the first, use: - first"})')
 
     parser.add_argument('-V', '--version',
                         action='version',

--- a/neurotic/scripts.py
+++ b/neurotic/scripts.py
@@ -55,7 +55,7 @@ def parse_args(argv):
     parser.add_argument('dataset', nargs='?',
                         help='the name of a dataset in the metadata file to '
                              'select initially'
-                             f' (default: {"the first entry in the metadata file" if defaults["dataset"] is None else defaults["dataset"] + "; to force the first, use: - none"})')
+                             f' (default: {"the first entry in the metadata file" if defaults["dataset"] is None else defaults["dataset"] + "; to force the first, use: - first"})')
 
     parser.add_argument('-V', '--version',
                         action='version',
@@ -134,17 +134,18 @@ def parse_args(argv):
         for k, v in _global_config_factory_defaults['defaults'].items():
             setattr(args, k, v)
 
+    # this special value for the first positional argument can be used to skip
+    # specifying any file and instead use the default file
+    if args.file == '-':
+        args.file = defaults['file']
+
     # these special values for the positional arguments can be used to override
     # the defaults set in the global config file with the defaults normally set
     # in the absence of global config file settings
-    if args.file == '-':
-        args.file = defaults['file']
-    elif args.file == 'example':
-        args.file = None
-    if args.dataset == '-':
-        args.dataset = defaults['dataset']
-    elif args.dataset == 'none':
-        args.dataset = None
+    if args.file == 'example':
+        args.file = _global_config_factory_defaults['defaults']['file']
+    if args.dataset == 'first':
+        args.dataset = _global_config_factory_defaults['defaults']['dataset']
 
     if args.debug:
         logger.parent.setLevel(logging.DEBUG)

--- a/neurotic/tests/test_cli.py
+++ b/neurotic/tests/test_cli.py
@@ -82,7 +82,7 @@ class CLITestCase(unittest.TestCase):
         # substitute special values
         if neurotic.global_config['defaults']['file'] == 'example':
             neurotic.global_config['defaults']['file'] = None
-        if neurotic.global_config['defaults']['dataset'] == 'none':
+        if neurotic.global_config['defaults']['dataset'] == 'first':
             neurotic.global_config['defaults']['dataset'] = None
 
         self.assertEqual(neurotic.global_config,
@@ -256,10 +256,10 @@ class CLITestCase(unittest.TestCase):
                          'dataset was not changed correctly')
 
     def test_example_file_and_first_dataset_overrides(self):
-        """Test that 'example' and 'none' open first dataset in example file"""
+        """Test that 'example' and 'first' open first dataset in example file"""
         neurotic.global_config['defaults']['file'] = 'some other file'
         neurotic.global_config['defaults']['dataset'] = 'some other dataset'
-        argv = ['neurotic', 'example', 'none']
+        argv = ['neurotic', 'example', 'first']
         args = neurotic.parse_args(argv)
         win = neurotic.win_from_args(args)
         self.assertEqual(win.metadata_selector.file, self.example_file,

--- a/neurotic/tests/test_cli.py
+++ b/neurotic/tests/test_cli.py
@@ -79,12 +79,6 @@ class CLITestCase(unittest.TestCase):
                 print(line, end='')  # stdout is redirected into the file
         neurotic.update_global_config_from_file(self.temp_global_config_file)
 
-        # substitute special values
-        if neurotic.global_config['defaults']['file'] == 'example':
-            neurotic.global_config['defaults']['file'] = None
-        if neurotic.global_config['defaults']['dataset'] == 'first':
-            neurotic.global_config['defaults']['dataset'] = None
-
         self.assertEqual(neurotic.global_config,
                          neurotic._global_config_factory_defaults,
                          'global_config loaded from template global config '


### PR DESCRIPTION
* In the global config file, in addition to `"example"`, `false` may be used to choose the factory default example file.
* In the global config file, instead of `"none"`, `"first"` or `false` must be used to choose the factory default first dataset.
* In the CLI, instead of `none`, `first` must be used to override the global config file's stored value and choose the factory default first dataset.