### PR TITLE
Automatically check for updates when app is launched

### DIFF
--- a/neurotic/__init__.py
+++ b/neurotic/__init__.py
@@ -78,6 +78,7 @@ logger.addHandler(logger_streamhandler)
 
 
 global_config = {
+    'auto_check_for_updates': True,
     'defaults': {
         # defaults used by the command line interface
         'file': False,

--- a/neurotic/global_config_template.txt
+++ b/neurotic/global_config_template.txt
@@ -2,6 +2,9 @@
 # Use this file to configure the way neurotic behaves. This file uses the TOML
 # format.
 
+# When the app is launched, neurotic automatically checks for updates unless
+# this parameter is set to false.
+# auto_check_for_updates = true
 
 [defaults]
 # When the app is launched, the following customizable defaults are used unless


### PR DESCRIPTION
Automatic checks can be disabled by setting `auto_check_for_updates = false` in the global config file.

Closes #257.