### PR TITLE
Fix GitHub Actions tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     env:
       DISPLAY: ':99.0'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
         - name: Set up virtual framebuffer (xvfb) for Qt GUI testing
           # https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions
           run: |
-            sudo apt-get install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
+            sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils
             /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
 
         - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
         - name: Set up Python 3.7
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
             python-version: 3.7
 
         - name: Checkout repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
 
         - name: Install package from repository with docs dependencies
           run: |
@@ -52,7 +52,7 @@ jobs:
         #     source activate test-environment
 
         - name: Checkout repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
 
         - name: Install package from repository with tests dependencies
           run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,7 @@ jobs:
 
         - name: Run tests
           run: |
-            nosetests --with-coverage --cover-package=neurotic
+            pytest -v --cov
 
         - name: Report coverage to Coveralls
           run: coveralls

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2021 Jeffrey Gill
+Copyright (c) 2019-2022 Jeffrey Gill
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ share the *neurotic* experience with your colleagues! 🤪
 Installing *neurotic*
 ---------------------
 
-*neurotic* requires Python 3.6 or later.
+*neurotic* requires Python 3.7 or later.
 
 Standalone Installers (recommended for beginners)
 .................................................

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'neurotic'
-copyright = '2021, Jeffrey Gill'
+copyright = '2022, Jeffrey Gill'
 author = 'Jeffrey Gill'
 
 import neurotic

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,7 +3,7 @@
 Installing *neurotic*
 =====================
 
-*neurotic* requires Python 3.6 or later.
+*neurotic* requires Python 3.7 or later.
 
 .. _installation-installers:
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,7 +1,5 @@
-# these restricted versions are defaults on ReadTheDocs, so use the same in
-# local builds and in tests
-sphinx<2
-readthedocs-sphinx-ext<2.2
+sphinx
+readthedocs-sphinx-ext
 
 # for inserting CLI usage printout into docs
 sphinxcontrib-programoutput

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,2 +1,3 @@
 coveralls
-nose
+pytest
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # av  # required but typically not installable via pip, try `conda install -c conda-forge av`
 ephyviewer>=1.3.0
-neo>=0.7.2
+neo>=0.7.2,<0.10.0  # TODO: fix for neo>=0.10
 numpy
 packaging
 pandas

--- a/setup.py
+++ b/setup.py
@@ -117,10 +117,11 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Scientific/Engineering',
     ],
 )


### PR DESCRIPTION
Dropped support for Python 3.6. Added testing against Python 3.10 and 3.11.

Temporarily pinned Neo to an old version to avoid [this issue](https://github.com/jpgill86/neurotic/issues/319#issuecomment-966586138) with `SpikeTrainList`. The incompatibility will be fixed and the pinning reverted shortly.