### PR TITLE
Fix hexadecimal color codes in examples and docs for PyQtGraph>=0.13.0

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -409,7 +409,9 @@ Plot Parameters
 Use the ``plots`` parameter to specify which signal channels from ``data_file``
 you want plotted and how to scale them. Optionally, a color may be specified
 for channels using a single letter color code (e.g., ``'b'`` for blue or
-``'k'`` for black) or a hexadecimal color code (e.g., ``'1b9e77'``).
+``'k'`` for black) or a hexadecimal color code (e.g., ``'#1b9e77'``; note that
+with PyQtGraph 0.13.0 and later, hexadecimal color codes must begin with
+``#``).
 
 Consider the following example, and notice the use of hyphens and indentation
 for each channel.
@@ -431,7 +433,7 @@ for each channel.
               ylabel: B3 neuron
               units: mV
               ylim: [-100, 50]
-              color: '666666'
+              color: '#666666'
 
             - channel: Force
               units: mN
@@ -536,7 +538,9 @@ loading is off (``lazy=False``).
 Detected spikes are indicated on the signals with markers, and spike trains are
 displayed in a raster plot. Optionally, a color may be specified for an
 amplitude discriminator using a single letter color code (e.g., ``'b'`` for
-blue or ``'k'`` for black) or a hexadecimal color code (e.g., ``'1b9e77'``).
+blue or ``'k'`` for black) or a hexadecimal color code (e.g., ``'#1b9e77'``;
+note that with PyQtGraph 0.13.0 and later, hexadecimal color codes must begin
+with ``#``).
 
 The algorithm can detect either peaks or troughs in the signal. When both the
 lower and upper bounds for amplitude windows are positive, the default behavior
@@ -572,7 +576,7 @@ for each amplitude discriminator.
               units: uV
               amplitude: [20, 50]
               epoch: Unit 2 activity
-              color: 'e6ab02'
+              color: '#e6ab02'
 
             - name: Unit 3
               channel: Intracellular

--- a/neurotic/datasets/metadata.py
+++ b/neurotic/datasets/metadata.py
@@ -383,7 +383,7 @@ def _defaults_for_key(key):
         'epoch_encoder_possible_labels': [],
 
         # list of dicts giving name, channel, units, amplitude window, epoch window, color for each unit
-        # - e.g. [{'name': 'Unit X', 'channel': 'Channel A', 'units': 'uV', 'amplitude': [75, 150], 'epoch': 'Type 1', 'color': 'ff0000'}, ...]
+        # - e.g. [{'name': 'Unit X', 'channel': 'Channel A', 'units': 'uV', 'amplitude': [75, 150], 'epoch': 'Type 1', 'color': '#ff0000'}, ...]
         'amplitude_discriminators': None,
 
         # list of dicts giving name of a spiketrain, start and stop firing rate
@@ -441,7 +441,7 @@ def _defaults_for_key(key):
         'video_rate_correction': None,
 
         # list the channels in the order they should be plotted
-        # - e.g. [{'channel': 'Channel A', 'ylabel': 'My channel', 'ylim': [-120, 120], 'units': 'uV', 'color': 'ff0000'}, ...]
+        # - e.g. [{'channel': 'Channel A', 'ylabel': 'My channel', 'ylim': [-120, 120], 'units': 'uV', 'color': '#ff0000'}, ...]
         'plots': None,
 
         # amount of time in seconds to plot initially

--- a/neurotic/example/metadata.yml
+++ b/neurotic/example/metadata.yml
@@ -44,30 +44,30 @@ Aplysia feeding:
           ylabel: I2 muscle EMG
           units: uV
           ylim: [-60, 60]
-          color: '666666'
+          color: '#666666'
 
         - channel: RN
           ylabel: Radular nerve (RN)
           units: uV
           ylim: [-25, 25]
-          color: '666666'
+          color: '#666666'
 
         - channel: BN2
           ylabel: Buccal nerve 2 (BN2)
           units: uV
           ylim: [-45, 45]
-          color: '666666'
+          color: '#666666'
 
         - channel: BN3-DIST
           ylabel: Buccal nerve 3 (BN3)
           units: uV
           ylim: [-60, 60]
-          color: '666666'
+          color: '#666666'
 
         - channel: Force
           units: mN
           ylim: [-50, 450]
-          color: '666666'
+          color: '#666666'
 
     # SIGNAL FILTERS
     # - used here to remove high-frequency noise
@@ -88,42 +88,42 @@ Aplysia feeding:
           units: uV
           amplitude: [7, 20]
           epoch: B38 activity
-          color: 'EFBF46'
+          color: '#EFBF46'
 
         - name: B31/B32/B61/B62 neurons
           channel: I2
           units: uV
           amplitude: [2, 75]
           epoch: I2 protraction activity
-          color: 'DC5151'
+          color: '#DC5151'
 
         - name: B8a/b neurons
           channel: RN
           units: uV
           amplitude: [-30, -8]
           epoch: B8 activity
-          color: 'DA8BC3'
+          color: '#DA8BC3'
 
         - name: B6/B9 neurons
           channel: BN2
           units: uV
           amplitude: [-25, -9]
           epoch: B3/6/9/10 activity
-          color: '64B5CD'
+          color: '#64B5CD'
 
         - name: B3 neuron
           channel: BN2
           units: uV
           amplitude: [-60, -25]
           epoch: B3/6/9/10 activity
-          color: '4F80BD'
+          color: '#4F80BD'
 
         - name: B4/B5 neurons
           channel: BN3-DIST
           units: uV
           amplitude: [-80, -20]
           epoch: B4/B5 activity
-          color: '00A86B'
+          color: '#00A86B'
 
     # NEURONAL FIRING RATES
     # - used here to model synaptic output


### PR DESCRIPTION
With PyQtGraph 0.13.0 and later, hexadecimal color codes must begin with ``#``.