### PR TITLE
Show epoch encoder even when no labels are given (as long as a file is)

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -475,9 +475,9 @@ to display "the past" and the last 70% to display "the future".
 Epoch Encoder Parameters
 ------------------------
 
-The labels available to the epoch encoder must be specified ahead of time using
-``epoch_encoder_possible_labels`` (this is a current limitation of ephyviewer
-that may eventually be improved upon).
+The labels available to the epoch encoder can be specified using
+``epoch_encoder_possible_labels``. (Additionally, they may be created on the
+fly using the "New label" button in the epoch encoder.)
 
 For example:
 

--- a/neurotic/gui/config.py
+++ b/neurotic/gui/config.py
@@ -690,32 +690,24 @@ class EphyviewerConfigurator():
                 if label not in possible_labels:
                     possible_labels.append(label)
 
-            if not possible_labels:
+            writable_epoch_source = NeuroticWritableEpochSource(
+                filename = _abs_path(self.metadata, 'epoch_encoder_file'),
+                possible_labels = possible_labels,
+            )
 
-                # an empty epoch encoder file and an empty list of possible
-                # labels were provided
-                logger.warning('Ignoring epoch_encoder_file because epoch_encoder_possible_labels was unspecified')
+            epoch_encoder = ephyviewer.EpochEncoder(source = writable_epoch_source, name = 'Epoch encoder')
+            epoch_encoder.params['exclusive_mode'] = False
+            win.add_view(epoch_encoder)
 
-            else:
+            # set the theme
+            if theme != 'original':
+                epoch_encoder.params['background_color'] = self.themes[theme]['background_color']
+                epoch_encoder.params['vline_color'] = self.themes[theme]['vline_color']
+                epoch_encoder.params['label_fill_color'] = self.themes[theme]['label_fill_color']
+                # TODO add support for combo_cmap
 
-                writable_epoch_source = NeuroticWritableEpochSource(
-                    filename = _abs_path(self.metadata, 'epoch_encoder_file'),
-                    possible_labels = possible_labels,
-                )
-
-                epoch_encoder = ephyviewer.EpochEncoder(source = writable_epoch_source, name = 'Epoch encoder')
-                epoch_encoder.params['exclusive_mode'] = False
-                win.add_view(epoch_encoder)
-
-                # set the theme
-                if theme != 'original':
-                    epoch_encoder.params['background_color'] = self.themes[theme]['background_color']
-                    epoch_encoder.params['vline_color'] = self.themes[theme]['vline_color']
-                    epoch_encoder.params['label_fill_color'] = self.themes[theme]['label_fill_color']
-                    # TODO add support for combo_cmap
-
-                epoch_encoder.params['xratio'] = self.metadata.get('past_fraction', 0.3)
-                epoch_encoder.params['label_size'] = ui_scales[ui_scale]['channel_label_size']
+            epoch_encoder.params['xratio'] = self.metadata.get('past_fraction', 0.3)
+            epoch_encoder.params['label_size'] = ui_scales[ui_scale]['channel_label_size']
 
         ########################################################################
         # VIDEO

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # av  # required but typically not installable via pip, try `conda install -c conda-forge av`
-ephyviewer>=1.3.0
+ephyviewer>=1.4.0
 neo>=0.7.2
 numpy
 packaging


### PR DESCRIPTION
Closes #317

Previously, if `epoch_encoder_possible_labels` was not specified, and if an empty file was provided for `epoch_encoder_file`, the epoch encoder would not load at all. A minimum of one possible label needed to be provided in metadata.

With this change, no possible labels need be specified in metadata for the epoch encoder to load. Using the epoch encoder's "New label" button (ephyviewer >= 1.4.0), possible labels can be created entirely on the fly.